### PR TITLE
[feat] add: Tailscale連携によるリモートアクセス基盤の構築

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## アーキテクチャ（4層構造）
 
 ```
-Repository層 (GSheetLoader)      ← Google Sheets との通信
+Repository層 (CsvRepository)     ← ローカル CSV ファイルの読み書き
     ↓
 Domain層 (DataProcessor)         ← データ正規化・3種データセット生成
     ↓
@@ -84,8 +84,10 @@ SkinJournal/
 │               │   ├── SkinRadarChart.tsx       # レーダーチャート（最新肌状態）
 │               │   ├── PeriodSelector.tsx       # 期間トグル（週/月/全期間）
 │               │   └── SnsExportButton.tsx      # SNS用画像書き出し
-│               └── DataTable/       # PBI-02: データテーブルビュー
-│                   └── index.tsx    # 正規化済みデータ一覧・データセット概要
+│               ├── DataTable/       # PBI-02: データテーブルビュー
+│               │   └── index.tsx    # 正規化済みデータ一覧・データセット概要
+│               └── CosmeticsMasterEditor/  # 化粧品マスタ編集画面（/settings）
+│                   └── index.tsx    # メーカー・品名・使用期間管理
 ```
 
 ## セットアップ
@@ -110,14 +112,14 @@ cp packages/backend/.env.example packages/backend/.env
 | カラム名 | 内容 |
 |---|---|
 | timestamp | 記録日時（ISO 8601） |
-| foreheadTone | おでこ・白さ（1〜10） |
-| foreheadMoisture | おでこ・水分（1〜10） |
-| foreheadOil | おでこ・油分（1〜10） |
-| foreheadElasticity | おでこ・弾力（1〜10） |
-| cheekTone | ほお・白さ（1〜10） |
-| cheekMoisture | ほお・水分（1〜10） |
-| cheekOil | ほお・油分（1〜10） |
-| cheekElasticity | ほお・弾力（1〜10） |
+| foreheadTone | おでこ・肌色（0〜100） |
+| foreheadMoisture | おでこ・水分量（0〜100） |
+| foreheadOil | おでこ・油分量（0〜100） |
+| foreheadElasticity | おでこ・弾性力（0〜100） |
+| cheekTone | ほお・肌色（0〜100） |
+| cheekMoisture | ほお・水分量（0〜100） |
+| cheekOil | ほお・油分量（0〜100） |
+| cheekElasticity | ほお・弾性力（0〜100） |
 | toner | 化粧水 |
 | essence | 美容液 |
 | lotion | 乳液 |
@@ -138,22 +140,72 @@ npm run dev
 
 ## 本番環境（Mac mini + pm2）
 
+### 1. ビルドと起動
+
 ```bash
-# ビルド
+# フロントをビルドしてバックエンドの public/ に出力
 npm run build
 
-# pm2 で起動
+# ecosystem.config.cjs の cwd をMac miniの絶対パスに変更してから起動
 pm2 start ecosystem.config.cjs
 
 # 起動確認
 pm2 status
-pm2 logs skin-journal-backend
 ```
+
+### 2. Mac mini 再起動後の自動起動設定
+
+```bash
+# 初回のみ実行（表示されるコマンドをコピーして実行）
+pm2 startup
+
+# 現在の起動プロセスを保存
+pm2 save
+```
+
+### 3. pm2 運用コマンド
+
+```bash
+pm2 status                          # プロセス一覧・状態確認
+pm2 logs skin-journal-backend       # リアルタイムログ表示
+pm2 logs skin-journal-backend --lines 100  # 直近100行のログ表示
+pm2 restart skin-journal-backend    # 再起動
+pm2 stop skin-journal-backend       # 停止
+pm2 delete skin-journal-backend     # プロセス削除
+```
+
+## Tailscale 経由のリモートアクセス
+
+### セットアップ
+
+1. **Mac mini 側**: [Tailscale](https://tailscale.com/download) をインストールしてログイン
+2. **スマホ・PC 側**: 同じ Tailscaleアカウントでログイン
+3. Tailscale 管理画面（admin.tailscale.com）で Mac mini の IP アドレスを確認
+
+### .env の設定
+
+```bash
+cp packages/backend/.env.example packages/backend/.env
+```
+
+`packages/backend/.env` を編集し、`CORS_ORIGIN` に Tailscale IP を追加:
+
+```env
+CORS_ORIGIN=http://localhost:5173,http://100.x.x.x:3001
+```
+
+または `ecosystem.config.cjs` の `env.CORS_ORIGIN` を直接編集してください。
+
+### アクセス
+
+```
+http://<Tailscale-IP>:3001
+```
+
+> 例: `http://100.64.0.1:3001`
 
 ## API エンドポイント
 
-| メソッド | パス | 説明 |
-|---|---|---|
 | メソッド | パス | 説明 |
 |---|---|---|
 | GET | `/api/records?period=week\|month\|all` | 正規化済みレコード一覧 |
@@ -161,10 +213,11 @@ pm2 logs skin-journal-backend
 | GET | `/api/latest` | 最新レコードと平均スコア |
 | POST | `/api/entry` | 新規エントリ保存（CSV追記） |
 | GET | `/api/export/csv` | CSV ファイルダウンロード |
-| GET | `/api/cosmetics-master` | 化粧品マスタ |
+| GET | `/api/cosmetics-master` | 化粧品マスタ取得 |
+| PUT | `/api/cosmetics-master` | 化粧品マスタ更新 |
 | GET | `/health` | ヘルスチェック |
 
 ## Git 運用ルール
 
-- Branch: `feature/pbi-XX-description` → Develop → Main
+- Branch: `Koichiro/Milestone_X_description` → Main
 - Commit prefix: `[Add]` `[Fix]` `[Update]` `[Docs]`

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,22 +1,25 @@
-// pm2 設定ファイル（Mac mini 常時稼働環境 - PBI-04）
+// pm2 設定ファイル（Mac mini 常時稼働環境）
 module.exports = {
   apps: [
     {
       name: 'skin-journal-backend',
       script: 'packages/backend/dist/index.js',
-      cwd: '/path/to/SkinJournal',  // Mac mini 上のパスに変更すること
+      cwd: '/path/to/SkinJournal',  // Mac mini 上の絶対パスに変更すること
       env: {
         NODE_ENV: 'production',
         PORT: 3001,
+        // Tailscale IP をカンマ区切りで追加（例: http://100.x.x.x:3001）
+        CORS_ORIGIN: 'http://localhost:5173',
+        // DATA_DIR: '/path/to/SkinJournal/packages/backend/data',
       },
       instances: 1,
       autorestart: true,
       watch: false,
       max_memory_restart: '512M',
-      log_file: 'logs/pm2-combined.log',
-      error_file: 'logs/pm2-error.log',
-      out_file: 'logs/pm2-out.log',
-      time: true,
+      log_date_format: 'YYYY-MM-DD HH:mm:ss',
+      error_file: 'packages/backend/logs/pm2-error.log',
+      out_file: 'packages/backend/logs/pm2-out.log',
+      merge_logs: true,
     },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "dev": "concurrently \"npm run dev --workspace=packages/backend\" \"npm run dev --workspace=packages/frontend\"",
-    "build": "npm run build --workspace=packages/backend && npm run build --workspace=packages/frontend",
+    "build": "npm run build --workspace=packages/frontend && npm run build --workspace=packages/backend",
     "lint": "npm run lint --workspace=packages/frontend && npm run lint --workspace=packages/backend",
     "format": "prettier --write \"packages/**/*.{ts,tsx,json}\""
   },

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -4,9 +4,4 @@ CORS_ORIGIN=http://localhost:5173
 # データ保存先ディレクトリ（デフォルト: packages/backend/data/）
 # DATA_DIR=/absolute/path/to/data
 
-# 化粧品マスタ（カンマ区切り）
-TONERS=化粧水A,化粧水B,化粧水C
-ESSENCES=美容液A,美容液B,美容液C
-LOTIONS=乳液A,乳液B,乳液C
-
 LOG_LEVEL=info

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -3,6 +3,7 @@
 // ============================================================
 
 import 'dotenv/config';
+import path from 'path';
 import express from 'express';
 import cors from 'cors';
 import { AppController } from './orchestration/AppController';
@@ -11,8 +12,11 @@ import logger from './utils/logger';
 const app = express();
 const PORT = parseInt(process.env.PORT ?? '3001', 10);
 
-// Middleware
-app.use(cors({ origin: process.env.CORS_ORIGIN ?? 'http://localhost:5173' }));
+// CORS: 環境変数 CORS_ORIGIN をカンマ区切りで複数指定可
+const corsOrigins = (process.env.CORS_ORIGIN ?? 'http://localhost:5173')
+  .split(',')
+  .map((o) => o.trim());
+app.use(cors({ origin: corsOrigins }));
 app.use(express.json());
 
 // API Routes
@@ -24,9 +28,18 @@ app.get('/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
 
+// 静的ファイル配信（本番ビルド）
+const publicDir = path.join(__dirname, '../public');
+app.use(express.static(publicDir));
+
+// SPA フォールバック: API 以外はすべて index.html を返す
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(publicDir, 'index.html'));
+});
+
 // Start server
-app.listen(PORT, () => {
-  logger.info(`SkinJournal backend server running on port ${PORT}`);
+app.listen(PORT, '0.0.0.0', () => {
+  logger.info(`SkinJournal backend server running on port ${PORT} (0.0.0.0)`);
 });
 
 export default app;

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
     },
   },
   build: {
+    outDir: '../backend/public',
+    emptyOutDir: true,
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
## Why
Mac mini上のアプリはVite開発サーバー（localhost:5173）とバックエンド（localhost:3001）がそれぞれ別ポートで動作しており、Tailscale経由でスマホ・外部端末からアクセスできない状態だった。また、Mac mini再起動後にアプリが自動起動しないため、外出先から常時アクセスできる環境が整っていなかった。

resolves #8
resolves #9
resolves #10
resolves #11

## What
フロントエンドをビルドしてバックエンドから静的配信する構成に変更し、ポートを3001に一本化。バインドアドレスとCORS設定をTailscale経由アクセスに対応させ、pm2による自動起動環境を整備した。

## How
- `vite.config.ts` のビルド出力先を `../backend/public` に変更
- Express に `express.static('public')` と SPAフォールバック（`* → index.html`）を追加
- `app.listen` を `0.0.0.0` にバインドし外部からのアクセスを許可
- `CORS_ORIGIN` を環境変数からカンマ区切りで複数オリジン対応に変更
- `ecosystem.config.cjs` にログ出力先・`CORS_ORIGIN` 設定例を追加
- README にTailscaleセットアップ手順・pm2運用コマンド一覧を追記
- README・`.env.example` の各種不整合を修正（アーキテクチャ図・CSVカラム表・APIエンドポイント表など）

## Test
- `npm run build` でフロントが `packages/backend/public/` にビルドされること
- ビルド後に `node packages/backend/dist/index.js` を起動し、`http://localhost:3001` でアプリが表示されること
- Mac miniとスマホをTailscaleで同一ネットワークに接続し、`http://<Tailscale-IP>:3001` でアプリが表示されること ✅ **接続確認済み**
- スマホから肌状態の記録・ダッシュボード閲覧が正常に動作すること