### PR TITLE
[feat] add: リファクタリング・UI改善・分析強化

### DIFF
--- a/packages/backend/src/domain/DataProcessor.ts
+++ b/packages/backend/src/domain/DataProcessor.ts
@@ -15,9 +15,9 @@ import {
 import logger from '../utils/logger';
 
 export class DataProcessor {
-  /** 弾力スコアを正規化する（1〜10 → 0.0〜1.0 の範囲にクランプ） */
+  /** スコアを 0〜100 の範囲にクランプする */
   private clampScore(value: number): number {
-    return Math.min(10, Math.max(1, value));
+    return Math.min(100, Math.max(0, value));
   }
 
   /** 文字列を数値にパース（不正値は0） */

--- a/packages/backend/src/orchestration/AppController.ts
+++ b/packages/backend/src/orchestration/AppController.ts
@@ -144,6 +144,39 @@ export class AppController {
       }
     });
 
+    /** PUT /api/records/:id - レコードを更新する（:id は encodeURIComponent(timestamp)） */
+    this.router.put('/records/:id', async (req: Request, res: Response) => {
+      try {
+        const timestamp = decodeURIComponent(req.params.id);
+        const entry = req.body as SkinEntryInput;
+        const updated = await this.repository.updateRow(timestamp, entry);
+        if (!updated) {
+          res.status(404).json({ success: false, error: 'レコードが見つかりません' });
+          return;
+        }
+        res.json({ success: true });
+      } catch (error) {
+        logger.error('PUT /records/:id error', error);
+        res.status(500).json({ success: false, error: '更新に失敗しました' });
+      }
+    });
+
+    /** DELETE /api/records/:id - レコードを削除する（:id は encodeURIComponent(timestamp)） */
+    this.router.delete('/records/:id', async (req: Request, res: Response) => {
+      try {
+        const timestamp = decodeURIComponent(req.params.id);
+        const deleted = await this.repository.deleteRow(timestamp);
+        if (!deleted) {
+          res.status(404).json({ success: false, error: 'レコードが見つかりません' });
+          return;
+        }
+        res.json({ success: true });
+      } catch (error) {
+        logger.error('DELETE /records/:id error', error);
+        res.status(500).json({ success: false, error: '削除に失敗しました' });
+      }
+    });
+
     /** GET /api/cosmetics-master - 化粧品マスタを返す */
     this.router.get('/cosmetics-master', (_req: Request, res: Response) => {
       try {

--- a/packages/backend/src/repository/CsvRepository.ts
+++ b/packages/backend/src/repository/CsvRepository.ts
@@ -103,8 +103,61 @@ export class CsvRepository {
     logger.info(`Appended new row at ${timestamp}`);
   }
 
+  /** timestamp が一致する行を更新して CSV 全体を書き直す */
+  async updateRow(timestamp: string, entry: SkinEntryInput): Promise<boolean> {
+    const rows = await this.loadAllRows();
+    const index = rows.findIndex((r) => r.timestamp === timestamp);
+    if (index === -1) return false;
+
+    const newTimestamp = entry.date ? `${entry.date}T00:00:00.000` : timestamp;
+    const updated: RawSheetRow = {
+      timestamp: newTimestamp,
+      foreheadTone: String(entry.forehead.tone),
+      foreheadMoisture: String(entry.forehead.moisture),
+      foreheadOil: String(entry.forehead.oil),
+      foreheadElasticity: String(entry.forehead.elasticity),
+      cheekTone: String(entry.cheek.tone),
+      cheekMoisture: String(entry.cheek.moisture),
+      cheekOil: String(entry.cheek.oil),
+      cheekElasticity: String(entry.cheek.elasticity),
+      toner: entry.cosmetics.toner,
+      essence: entry.cosmetics.essence,
+      lotion: entry.cosmetics.lotion,
+      businessTrip: entry.factors.businessTrip ? 'TRUE' : 'FALSE',
+      alcohol: entry.factors.alcohol ? 'TRUE' : 'FALSE',
+      sleepHours: String(entry.factors.sleepHours),
+      notes: entry.factors.notes,
+    };
+    rows[index] = updated;
+    this.writeAllRows(rows);
+    logger.info(`Updated row with timestamp: ${timestamp}`);
+    return true;
+  }
+
+  /** timestamp が一致する行を削除して CSV 全体を書き直す */
+  async deleteRow(timestamp: string): Promise<boolean> {
+    const rows = await this.loadAllRows();
+    const filtered = rows.filter((r) => r.timestamp !== timestamp);
+    if (filtered.length === rows.length) return false;
+    this.writeAllRows(filtered);
+    logger.info(`Deleted row with timestamp: ${timestamp}`);
+    return true;
+  }
+
   /** CSV ファイルのパスを返す（ダウンロード用） */
   getCsvPath(): string {
     return this.csvPath;
+  }
+
+  private writeAllRows(rows: RawSheetRow[]): void {
+    const lines = rows.map((r) =>
+      [
+        r.timestamp, r.foreheadTone, r.foreheadMoisture, r.foreheadOil, r.foreheadElasticity,
+        r.cheekTone, r.cheekMoisture, r.cheekOil, r.cheekElasticity,
+        r.toner, r.essence, r.lotion,
+        r.businessTrip, r.alcohol, r.sleepHours, r.notes,
+      ].map(escapeField).join(',')
+    );
+    fs.writeFileSync(this.csvPath, CSV_HEADERS.join(',') + '\n' + lines.join('\n') + (lines.length ? '\n' : ''), 'utf-8');
   }
 }

--- a/packages/frontend/src/components/CosmeticsMasterEditor/index.tsx
+++ b/packages/frontend/src/components/CosmeticsMasterEditor/index.tsx
@@ -11,6 +11,11 @@ import {
   CardContent,
   Chip,
   CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   Divider,
   IconButton,
   Snackbar,
@@ -143,7 +148,8 @@ function EditableRow({
   onUpdate: (updated: CosmeticItem) => void;
   onDelete: (id: string) => void;
 }) {
-  const [editing, setEditing]     = useState(false);
+  const [editing, setEditing]             = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const [draftMaker, setDraftMaker]       = useState(item.maker);
   const [draftName, setDraftName]         = useState(item.name);
   const [draftStart, setDraftStart]       = useState(item.startDate ?? '');
@@ -195,7 +201,28 @@ function EditableRow({
               <CloseIcon fontSize="small" />
             </IconButton>
           </Tooltip>
+          <Tooltip title="削除">
+            <IconButton size="small" color="error" onClick={() => setConfirmDelete(true)}>
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
         </TableCell>
+
+        {/* 削除確認ダイアログ */}
+        <Dialog open={confirmDelete} onClose={() => setConfirmDelete(false)}>
+          <DialogTitle>削除の確認</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              「{item.maker ? `${item.maker} / ` : ''}{item.name}」を削除しますか？この操作は元に戻せません。
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setConfirmDelete(false)}>キャンセル</Button>
+            <Button color="error" variant="contained" onClick={() => { setConfirmDelete(false); onDelete(item.id); }}>
+              削除
+            </Button>
+          </DialogActions>
+        </Dialog>
       </TableRow>
     );
   }
@@ -226,11 +253,6 @@ function EditableRow({
         <Tooltip title="編集">
           <IconButton size="small" onClick={() => setEditing(true)}>
             <EditIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="削除">
-          <IconButton size="small" color="error" onClick={() => onDelete(item.id)}>
-            <DeleteIcon fontSize="small" />
           </IconButton>
         </Tooltip>
       </TableCell>

--- a/packages/frontend/src/components/Dashboard/CosmeticsChart.tsx
+++ b/packages/frontend/src/components/Dashboard/CosmeticsChart.tsx
@@ -1,0 +1,97 @@
+// ============================================================
+// PBI-11: 化粧品別 平均肌スコア比較グラフ
+// ============================================================
+
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+} from 'recharts';
+import { Box, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import { useState } from 'react';
+import { NormalizedRecord } from '../../types';
+import { SCALE_MAX, METRIC_LABELS, METRIC_COLORS } from '../../constants';
+
+type CosmeticField = 'toner' | 'essence' | 'lotion';
+type AreaFilter = 'forehead' | 'cheek';
+
+const FIELD_LABELS: Record<CosmeticField, string> = {
+  toner: '化粧水',
+  essence: '美容液',
+  lotion: '乳液',
+};
+
+function buildChartData(records: NormalizedRecord[], field: CosmeticField, area: AreaFilter) {
+  const grouped = new Map<string, number[][]>();
+
+  for (const r of records) {
+    const name = r.cosmetics[field];
+    if (!name) continue;
+    if (!grouped.has(name)) grouped.set(name, [[], [], [], []]);
+    const metrics = r[area];
+    grouped.get(name)![0].push(metrics.tone);
+    grouped.get(name)![1].push(metrics.moisture);
+    grouped.get(name)![2].push(metrics.oil);
+    grouped.get(name)![3].push(metrics.elasticity);
+  }
+
+  return Array.from(grouped.entries()).map(([name, values]) => ({
+    name: name.length > 14 ? name.slice(0, 14) + '…' : name,
+    tone: parseFloat((values[0].reduce((a, b) => a + b, 0) / values[0].length).toFixed(1)),
+    moisture: parseFloat((values[1].reduce((a, b) => a + b, 0) / values[1].length).toFixed(1)),
+    oil: parseFloat((values[2].reduce((a, b) => a + b, 0) / values[2].length).toFixed(1)),
+    elasticity: parseFloat((values[3].reduce((a, b) => a + b, 0) / values[3].length).toFixed(1)),
+  }));
+}
+
+interface Props {
+  records: NormalizedRecord[];
+}
+
+export default function CosmeticsChart({ records }: Props) {
+  const [field, setField] = useState<CosmeticField>('toner');
+  const [area, setArea] = useState<AreaFilter>('forehead');
+
+  const data = buildChartData(records, field, area);
+
+  if (data.length === 0) {
+    return (
+      <Box display="flex" alignItems="center" justifyContent="center" height={300}>
+        <Typography color="text.secondary">データが不足しています（化粧品を記録してください）</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Box display="flex" gap={2} flexWrap="wrap" mb={2}>
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="body2" color="text.secondary">カテゴリ:</Typography>
+          <ToggleButtonGroup value={field} exclusive onChange={(_, v) => v && setField(v)} size="small">
+            {(Object.entries(FIELD_LABELS) as [CosmeticField, string][]).map(([k, l]) => (
+              <ToggleButton key={k} value={k}>{l}</ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </Box>
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="body2" color="text.secondary">部位:</Typography>
+          <ToggleButtonGroup value={area} exclusive onChange={(_, v) => v && setArea(v)} size="small">
+            <ToggleButton value="forehead">おでこ</ToggleButton>
+            <ToggleButton value="cheek">ほお</ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+      </Box>
+
+      <ResponsiveContainer width="100%" height={320}>
+        <BarChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 40 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis dataKey="name" tick={{ fontSize: 11 }} angle={-20} textAnchor="end" interval={0} />
+          <YAxis domain={[0, SCALE_MAX]} tickCount={6} tick={{ fontSize: 11 }} />
+          <Tooltip />
+          <Legend />
+          {(Object.keys(METRIC_LABELS) as Array<keyof typeof METRIC_LABELS>).map((key) => (
+            <Bar key={key} dataKey={key} name={METRIC_LABELS[key]} fill={METRIC_COLORS[key]} />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}

--- a/packages/frontend/src/components/Dashboard/FactorsChart.tsx
+++ b/packages/frontend/src/components/Dashboard/FactorsChart.tsx
@@ -1,0 +1,115 @@
+// ============================================================
+// PBI-12: 外部要因と肌状態の相関グラフ
+// ============================================================
+
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+  ScatterChart, Scatter, ZAxis,
+} from 'recharts';
+import { Box, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import { useState } from 'react';
+import { NormalizedRecord } from '../../types';
+import { SCALE_MAX, METRIC_LABELS, METRIC_COLORS } from '../../constants';
+
+type AreaFilter = 'forehead' | 'cheek';
+
+function avgMetrics(records: NormalizedRecord[], area: AreaFilter) {
+  if (records.length === 0) return { tone: 0, moisture: 0, oil: 0, elasticity: 0 };
+  const keys = ['tone', 'moisture', 'oil', 'elasticity'] as const;
+  return Object.fromEntries(
+    keys.map((k) => [k, parseFloat((records.reduce((s, r) => s + r[area][k], 0) / records.length).toFixed(1))])
+  ) as { tone: number; moisture: number; oil: number; elasticity: number };
+}
+
+// 飲酒・出張あり/なしで平均スコアを比較
+function buildBoolData(records: NormalizedRecord[], factor: 'alcohol' | 'businessTrip', area: AreaFilter) {
+  const yes = records.filter((r) => r.factors[factor]);
+  const no  = records.filter((r) => !r.factors[factor]);
+  const label = factor === 'alcohol' ? '飲酒' : '出張';
+  return [
+    { name: `${label}あり (${yes.length}件)`, ...avgMetrics(yes, area) },
+    { name: `${label}なし (${no.length}件)`, ...avgMetrics(no, area) },
+  ];
+}
+
+// 睡眠時間を2時間ごとにグループ化してスコア平均を算出
+function buildSleepData(records: NormalizedRecord[], area: AreaFilter) {
+  const groups = new Map<string, NormalizedRecord[]>();
+  for (const r of records) {
+    const bucket = `${Math.floor(r.factors.sleepHours / 2) * 2}〜${Math.floor(r.factors.sleepHours / 2) * 2 + 2}h`;
+    if (!groups.has(bucket)) groups.set(bucket, []);
+    groups.get(bucket)!.push(r);
+  }
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => parseFloat(a) - parseFloat(b))
+    .map(([bucket, recs]) => ({ name: bucket, ...avgMetrics(recs, area) }));
+}
+
+interface Props {
+  records: NormalizedRecord[];
+}
+
+type FactorMode = 'sleep' | 'alcohol' | 'businessTrip';
+
+const MODE_LABELS: Record<FactorMode, string> = {
+  sleep: '睡眠時間',
+  alcohol: '飲酒',
+  businessTrip: '出張',
+};
+
+export default function FactorsChart({ records }: Props) {
+  const [mode, setMode] = useState<FactorMode>('sleep');
+  const [area, setArea] = useState<AreaFilter>('forehead');
+
+  const data =
+    mode === 'sleep'
+      ? buildSleepData(records, area)
+      : buildBoolData(records, mode as 'alcohol' | 'businessTrip', area);
+
+  if (records.length === 0) {
+    return (
+      <Box display="flex" alignItems="center" justifyContent="center" height={300}>
+        <Typography color="text.secondary">データがありません</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Box display="flex" gap={2} flexWrap="wrap" mb={2}>
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="body2" color="text.secondary">要因:</Typography>
+          <ToggleButtonGroup value={mode} exclusive onChange={(_, v) => v && setMode(v)} size="small">
+            {(Object.entries(MODE_LABELS) as [FactorMode, string][]).map(([k, l]) => (
+              <ToggleButton key={k} value={k}>{l}</ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </Box>
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="body2" color="text.secondary">部位:</Typography>
+          <ToggleButtonGroup value={area} exclusive onChange={(_, v) => v && setArea(v)} size="small">
+            <ToggleButton value="forehead">おでこ</ToggleButton>
+            <ToggleButton value="cheek">ほお</ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+      </Box>
+
+      <ResponsiveContainer width="100%" height={320}>
+        <BarChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 20 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+          <YAxis domain={[0, SCALE_MAX]} tickCount={6} tick={{ fontSize: 11 }} />
+          <Tooltip />
+          <Legend />
+          {(Object.keys(METRIC_LABELS) as Array<keyof typeof METRIC_LABELS>).map((key) => (
+            <Bar key={key} dataKey={key} name={METRIC_LABELS[key]} fill={METRIC_COLORS[key]} />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}
+
+// ScatterChart と ZAxis はバンドルに含まれるよう import しているが、
+// 今後の散布図拡張時のために残しておく
+void ScatterChart; void Scatter; void ZAxis;

--- a/packages/frontend/src/components/Dashboard/SkinRadarChart.tsx
+++ b/packages/frontend/src/components/Dashboard/SkinRadarChart.tsx
@@ -14,24 +14,18 @@ import {
 } from 'recharts';
 import { Box, Typography } from '@mui/material';
 import { NormalizedRecord, RadarDataPoint } from '../../types';
+import { SCALE_MAX, METRIC_LABELS } from '../../constants';
 
 interface Props {
   record: NormalizedRecord | null;
 }
 
-const METRIC_LABELS: { key: string; label: string }[] = [
-  { key: 'tone', label: '白さ' },
-  { key: 'moisture', label: '水分' },
-  { key: 'oil', label: '油分' },
-  { key: 'elasticity', label: '弾力' },
-];
-
 function buildRadarData(record: NormalizedRecord): RadarDataPoint[] {
-  return METRIC_LABELS.map(({ key, label }) => ({
-    metric: label,
-    forehead: record.forehead[key as keyof typeof record.forehead],
-    cheek: record.cheek[key as keyof typeof record.cheek],
-    fullMark: 10,
+  return (Object.keys(METRIC_LABELS) as Array<keyof typeof record.forehead>).map((key) => ({
+    metric: METRIC_LABELS[key],
+    forehead: record.forehead[key],
+    cheek: record.cheek[key],
+    fullMark: SCALE_MAX,
   }));
 }
 
@@ -55,21 +49,9 @@ export default function SkinRadarChart({ record }: Props) {
         <RadarChart data={data}>
           <PolarGrid />
           <PolarAngleAxis dataKey="metric" tick={{ fontSize: 14 }} />
-          <PolarRadiusAxis angle={90} domain={[0, 10]} tickCount={6} tick={{ fontSize: 10 }} />
-          <Radar
-            name="おでこ"
-            dataKey="forehead"
-            stroke="#e91e63"
-            fill="#e91e63"
-            fillOpacity={0.3}
-          />
-          <Radar
-            name="ほお"
-            dataKey="cheek"
-            stroke="#2196f3"
-            fill="#2196f3"
-            fillOpacity={0.3}
-          />
+          <PolarRadiusAxis angle={90} domain={[0, SCALE_MAX]} tickCount={6} tick={{ fontSize: 10 }} />
+          <Radar name="おでこ" dataKey="forehead" stroke="#e91e63" fill="#e91e63" fillOpacity={0.3} />
+          <Radar name="ほお" dataKey="cheek" stroke="#2196f3" fill="#2196f3" fillOpacity={0.3} />
           <Legend />
           <Tooltip />
         </RadarChart>

--- a/packages/frontend/src/components/Dashboard/TrendChart.tsx
+++ b/packages/frontend/src/components/Dashboard/TrendChart.tsx
@@ -15,26 +15,13 @@ import {
 import { Box, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import { useState } from 'react';
 import { NormalizedRecord, TrendDataPoint } from '../../types';
+import { SCALE_MAX, METRIC_LABELS, METRIC_COLORS } from '../../constants';
 
 type AreaFilter = 'forehead' | 'cheek' | 'both';
 
 interface Props {
   records: NormalizedRecord[];
 }
-
-const COLORS = {
-  tone: '#e91e63',
-  moisture: '#2196f3',
-  oil: '#ff9800',
-  elasticity: '#4caf50',
-};
-
-const METRIC_LABELS = {
-  tone: '白さ',
-  moisture: '水分',
-  oil: '油分',
-  elasticity: '弾力',
-};
 
 function buildTrendData(records: NormalizedRecord[]): TrendDataPoint[] {
   return records.map((r) => ({
@@ -87,85 +74,25 @@ export default function TrendChart({ records }: Props) {
         <LineChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
           <XAxis dataKey="date" tick={{ fontSize: 11 }} />
-          <YAxis domain={[0, 10]} tickCount={6} tick={{ fontSize: 11 }} />
+          <YAxis domain={[0, SCALE_MAX]} tickCount={6} tick={{ fontSize: 11 }} />
           <Tooltip />
           <Legend />
 
           {showForehead && (
             <>
-              <Line
-                type="monotone"
-                dataKey="foreheadTone"
-                name={`おでこ・${METRIC_LABELS.tone}`}
-                stroke={COLORS.tone}
-                strokeWidth={2}
-                dot={{ r: 3 }}
-                strokeDasharray="6 2"
-              />
-              <Line
-                type="monotone"
-                dataKey="foreheadMoisture"
-                name={`おでこ・${METRIC_LABELS.moisture}`}
-                stroke={COLORS.moisture}
-                strokeWidth={2}
-                dot={{ r: 3 }}
-                strokeDasharray="6 2"
-              />
-              <Line
-                type="monotone"
-                dataKey="foreheadOil"
-                name={`おでこ・${METRIC_LABELS.oil}`}
-                stroke={COLORS.oil}
-                strokeWidth={2}
-                dot={{ r: 3 }}
-                strokeDasharray="6 2"
-              />
-              <Line
-                type="monotone"
-                dataKey="foreheadElasticity"
-                name={`おでこ・${METRIC_LABELS.elasticity}`}
-                stroke={COLORS.elasticity}
-                strokeWidth={2}
-                dot={{ r: 3 }}
-                strokeDasharray="6 2"
-              />
+              <Line type="monotone" dataKey="foreheadTone" name={`おでこ・${METRIC_LABELS.tone}`} stroke={METRIC_COLORS.tone} strokeWidth={2} dot={{ r: 3 }} strokeDasharray="6 2" />
+              <Line type="monotone" dataKey="foreheadMoisture" name={`おでこ・${METRIC_LABELS.moisture}`} stroke={METRIC_COLORS.moisture} strokeWidth={2} dot={{ r: 3 }} strokeDasharray="6 2" />
+              <Line type="monotone" dataKey="foreheadOil" name={`おでこ・${METRIC_LABELS.oil}`} stroke={METRIC_COLORS.oil} strokeWidth={2} dot={{ r: 3 }} strokeDasharray="6 2" />
+              <Line type="monotone" dataKey="foreheadElasticity" name={`おでこ・${METRIC_LABELS.elasticity}`} stroke={METRIC_COLORS.elasticity} strokeWidth={2} dot={{ r: 3 }} strokeDasharray="6 2" />
             </>
           )}
 
           {showCheek && (
             <>
-              <Line
-                type="monotone"
-                dataKey="cheekTone"
-                name={`ほお・${METRIC_LABELS.tone}`}
-                stroke={COLORS.tone}
-                strokeWidth={2}
-                dot={{ r: 3 }}
-              />
-              <Line
-                type="monotone"
-                dataKey="cheekMoisture"
-                name={`ほお・${METRIC_LABELS.moisture}`}
-                stroke={COLORS.moisture}
-                strokeWidth={2}
-                dot={{ r: 3 }}
-              />
-              <Line
-                type="monotone"
-                dataKey="cheekOil"
-                name={`ほお・${METRIC_LABELS.oil}`}
-                stroke={COLORS.oil}
-                strokeWidth={2}
-                dot={{ r: 3 }}
-              />
-              <Line
-                type="monotone"
-                dataKey="cheekElasticity"
-                name={`ほお・${METRIC_LABELS.elasticity}`}
-                stroke={COLORS.elasticity}
-                strokeWidth={2}
-                dot={{ r: 3 }}
-              />
+              <Line type="monotone" dataKey="cheekTone" name={`ほお・${METRIC_LABELS.tone}`} stroke={METRIC_COLORS.tone} strokeWidth={2} dot={{ r: 3 }} />
+              <Line type="monotone" dataKey="cheekMoisture" name={`ほお・${METRIC_LABELS.moisture}`} stroke={METRIC_COLORS.moisture} strokeWidth={2} dot={{ r: 3 }} />
+              <Line type="monotone" dataKey="cheekOil" name={`ほお・${METRIC_LABELS.oil}`} stroke={METRIC_COLORS.oil} strokeWidth={2} dot={{ r: 3 }} />
+              <Line type="monotone" dataKey="cheekElasticity" name={`ほお・${METRIC_LABELS.elasticity}`} stroke={METRIC_COLORS.elasticity} strokeWidth={2} dot={{ r: 3 }} />
             </>
           )}
         </LineChart>

--- a/packages/frontend/src/components/Dashboard/index.tsx
+++ b/packages/frontend/src/components/Dashboard/index.tsx
@@ -17,9 +17,12 @@ import {
 import PeriodSelector from './PeriodSelector';
 import TrendChart from './TrendChart';
 import SkinRadarChart from './SkinRadarChart';
+import CosmeticsChart from './CosmeticsChart';
+import FactorsChart from './FactorsChart';
 import SnsExportButton from './SnsExportButton';
 import { useSkinData } from '../../hooks/useSkinData';
 import { PeriodFilter } from '../../types';
+import { SCALE_MAX, getScoreColor } from '../../constants';
 
 export default function Dashboard() {
   const [period, setPeriod] = useState<PeriodFilter>('month');
@@ -59,10 +62,10 @@ export default function Dashboard() {
             {latestRecord && (
               <>
                 {[
-                  { label: 'おでこ 水分', value: latestRecord.forehead.moisture },
-                  { label: 'ほお 水分', value: latestRecord.cheek.moisture },
-                  { label: 'おでこ 弾力', value: latestRecord.forehead.elasticity },
-                  { label: 'ほお 弾力', value: latestRecord.cheek.elasticity },
+                  { label: 'おでこ 水分量', value: latestRecord.forehead.moisture },
+                  { label: 'ほお 水分量', value: latestRecord.cheek.moisture },
+                  { label: 'おでこ 弾性力', value: latestRecord.forehead.elasticity },
+                  { label: 'ほお 弾性力', value: latestRecord.cheek.elasticity },
                 ].map(({ label, value }) => (
                   <Grid item xs={6} sm={3} key={label}>
                     <Card elevation={2} sx={{ textAlign: 'center', py: 1 }}>
@@ -73,12 +76,12 @@ export default function Dashboard() {
                         <Typography
                           variant="h4"
                           fontWeight={700}
-                          color={value >= 7 ? 'success.main' : value >= 4 ? 'warning.main' : 'error.main'}
+                          color={`${getScoreColor(value)}.main`}
                         >
-                          {value.toFixed(1)}
+                          {value}
                         </Typography>
                         <Typography variant="caption" color="text.secondary">
-                          / 10
+                          / {SCALE_MAX}
                         </Typography>
                       </CardContent>
                     </Card>
@@ -95,18 +98,19 @@ export default function Dashboard() {
                     value={tab}
                     onChange={(_, v) => setTab(v)}
                     sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
+                    variant="scrollable"
+                    scrollButtons="auto"
                   >
                     <Tab label="推移グラフ" />
                     <Tab label="レーダーチャート（最新）" />
+                    <Tab label="化粧品比較" />
+                    <Tab label="外部要因分析" />
                   </Tabs>
 
-                  {tab === 0 && (
-                    <TrendChart records={records} />
-                  )}
-
-                  {tab === 1 && (
-                    <SkinRadarChart record={latestRecord} />
-                  )}
+                  {tab === 0 && <TrendChart records={records} />}
+                  {tab === 1 && <SkinRadarChart record={latestRecord} />}
+                  {tab === 2 && <CosmeticsChart records={records} />}
+                  {tab === 3 && <FactorsChart records={records} />}
                 </CardContent>
               </Card>
             </Grid>

--- a/packages/frontend/src/components/Dashboard/index.tsx
+++ b/packages/frontend/src/components/Dashboard/index.tsx
@@ -68,7 +68,7 @@ export default function Dashboard() {
                   { label: 'ほお 弾性力', value: latestRecord.cheek.elasticity },
                 ].map(({ label, value }) => (
                   <Grid item xs={6} sm={3} key={label}>
-                    <Card elevation={2} sx={{ textAlign: 'center', py: 1 }}>
+                    <Card elevation={0} sx={{ textAlign: 'center', py: 1 }}>
                       <CardContent>
                         <Typography variant="caption" color="text.secondary">
                           {label}
@@ -92,7 +92,7 @@ export default function Dashboard() {
 
             {/* グラフタブ */}
             <Grid item xs={12}>
-              <Card elevation={2}>
+              <Card elevation={0}>
                 <CardContent>
                   <Tabs
                     value={tab}

--- a/packages/frontend/src/components/DataTable/index.tsx
+++ b/packages/frontend/src/components/DataTable/index.tsx
@@ -22,20 +22,31 @@ import {
   TablePagination,
   Typography,
   Tooltip,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Slider,
+  TextField,
+  Checkbox,
+  FormControlLabel,
+  Snackbar,
 } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import DownloadIcon from '@mui/icons-material/Download';
-import { useSkinData } from '../../hooks/useSkinData';
-import { NormalizedRecord, SkinMetrics } from '../../types';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useSkinData, updateRecord, deleteRecord } from '../../hooks/useSkinData';
+import { NormalizedRecord, SkinMetrics, SkinEntryInput } from '../../types';
+import { METRIC_LABELS, METRIC_COLORS, getScoreColor, SCALE_MAX } from '../../constants';
 
-// スコアに応じた色付き表示
 function ScoreChip({ value }: { value: number }) {
-  const color = value >= 7 ? 'success' : value >= 4 ? 'warning' : 'error';
   return (
     <Chip
-      label={value.toFixed(1)}
-      color={color}
+      label={value}
+      color={getScoreColor(value)}
       size="small"
       sx={{ fontWeight: 700, minWidth: 48 }}
     />
@@ -45,38 +56,170 @@ function ScoreChip({ value }: { value: number }) {
 function MetricsCell({ metrics }: { metrics: SkinMetrics }) {
   return (
     <Box display="flex" gap={0.5} flexWrap="wrap">
-      <Tooltip title="白さ">
-        <Chip label={`白:${metrics.tone}`} size="small" variant="outlined" />
-      </Tooltip>
-      <Tooltip title="水分">
-        <Chip label={`水:${metrics.moisture}`} size="small" variant="outlined" sx={{ borderColor: '#2196f3', color: '#2196f3' }} />
-      </Tooltip>
-      <Tooltip title="油分">
-        <Chip label={`油:${metrics.oil}`} size="small" variant="outlined" sx={{ borderColor: '#ff9800', color: '#ff9800' }} />
-      </Tooltip>
-      <Tooltip title="弾力">
-        <Chip label={`弾:${metrics.elasticity}`} size="small" variant="outlined" sx={{ borderColor: '#4caf50', color: '#4caf50' }} />
-      </Tooltip>
+      {(Object.keys(METRIC_LABELS) as Array<keyof SkinMetrics>).map((key) => (
+        <Tooltip key={key} title={METRIC_LABELS[key]}>
+          <Chip
+            label={`${METRIC_LABELS[key][0]}:${metrics[key]}`}
+            size="small"
+            variant="outlined"
+            sx={{ borderColor: METRIC_COLORS[key], color: METRIC_COLORS[key] }}
+          />
+        </Tooltip>
+      ))}
     </Box>
   );
 }
 
 function BoolIcon({ value }: { value: boolean }) {
-  return value ? (
-    <CheckCircleIcon fontSize="small" color="success" />
-  ) : (
-    <CancelIcon fontSize="small" color="disabled" />
+  return value
+    ? <CheckCircleIcon fontSize="small" color="success" />
+    : <CancelIcon fontSize="small" color="disabled" />;
+}
+
+// ── 編集ダイアログ ────────────────────────────────────────
+function EditDialog({
+  record,
+  onClose,
+  onSave,
+}: {
+  record: NormalizedRecord;
+  onClose: () => void;
+  onSave: (entry: SkinEntryInput) => Promise<void>;
+}) {
+  const [forehead, setForehead] = useState<SkinMetrics>({ ...record.forehead });
+  const [cheek, setCheek] = useState<SkinMetrics>({ ...record.cheek });
+  const [toner, setToner] = useState(record.cosmetics.toner);
+  const [essence, setEssence] = useState(record.cosmetics.essence);
+  const [lotion, setLotion] = useState(record.cosmetics.lotion);
+  const [businessTrip, setBusinessTrip] = useState(record.factors.businessTrip);
+  const [alcohol, setAlcohol] = useState(record.factors.alcohol);
+  const [sleepHours, setSleepHours] = useState(record.factors.sleepHours);
+  const [notes, setNotes] = useState(record.factors.notes);
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    await onSave({
+      forehead, cheek,
+      cosmetics: { toner, essence, lotion },
+      factors: { businessTrip, alcohol, sleepHours, notes },
+    });
+    setSaving(false);
+  };
+
+  const MetricSliders = ({
+    label, value, onChange,
+  }: { label: string; value: SkinMetrics; onChange: (m: SkinMetrics) => void }) => (
+    <Box>
+      <Typography variant="subtitle2" gutterBottom>{label}</Typography>
+      {(Object.keys(METRIC_LABELS) as Array<keyof SkinMetrics>).map((key) => (
+        <Box key={key} display="flex" alignItems="center" gap={2} mb={0.5}>
+          <Typography variant="caption" sx={{ width: 48, flexShrink: 0 }}>{METRIC_LABELS[key]}</Typography>
+          <Slider
+            value={value[key]}
+            min={0} max={SCALE_MAX} step={1}
+            onChange={(_, v) => onChange({ ...value, [key]: v as number })}
+            sx={{ color: METRIC_COLORS[key] }}
+          />
+          <Typography variant="caption" sx={{ width: 28, textAlign: 'right' }}>{value[key]}</Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>記録を編集</DialogTitle>
+      <DialogContent dividers>
+        <Box display="flex" flexDirection="column" gap={3} pt={1}>
+          <MetricSliders label="おでこ" value={forehead} onChange={setForehead} />
+          <MetricSliders label="ほお" value={cheek} onChange={setCheek} />
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>使用化粧品</Typography>
+            <Box display="flex" flexDirection="column" gap={1}>
+              <TextField size="small" label="化粧水" value={toner} onChange={(e) => setToner(e.target.value)} fullWidth />
+              <TextField size="small" label="美容液" value={essence} onChange={(e) => setEssence(e.target.value)} fullWidth />
+              <TextField size="small" label="乳液" value={lotion} onChange={(e) => setLotion(e.target.value)} fullWidth />
+            </Box>
+          </Box>
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>ライフログ</Typography>
+            <Box display="flex" flexWrap="wrap" gap={2} alignItems="center">
+              <FormControlLabel
+                control={<Checkbox checked={businessTrip} onChange={(e) => setBusinessTrip(e.target.checked)} />}
+                label="出張"
+              />
+              <FormControlLabel
+                control={<Checkbox checked={alcohol} onChange={(e) => setAlcohol(e.target.checked)} />}
+                label="飲酒"
+              />
+              <TextField
+                size="small" type="number" label="睡眠時間"
+                value={sleepHours}
+                onChange={(e) => setSleepHours(parseFloat(e.target.value) || 0)}
+                inputProps={{ min: 0, max: 24, step: 0.5 }}
+                sx={{ width: 120 }}
+              />
+              <TextField
+                size="small" label="メモ" value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                sx={{ flex: 1, minWidth: 160 }}
+              />
+            </Box>
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>キャンセル</Button>
+        <Button variant="contained" onClick={handleSave} disabled={saving}>
+          {saving ? '保存中…' : '保存'}
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 }
 
-// 正規化済みデータのテーブル
-function NormalizedTable({ records }: { records: NormalizedRecord[] }) {
+// ── 正規化済みデータテーブル ────────────────────────────
+function NormalizedTable({
+  records,
+  onRefetch,
+}: {
+  records: NormalizedRecord[];
+  onRefetch: () => void;
+}) {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [editRecord, setEditRecord] = useState<NormalizedRecord | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<NormalizedRecord | null>(null);
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
+    open: false, message: '', severity: 'success',
+  });
 
   const paginated = [...records]
     .reverse()
     .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
+
+  const handleSave = async (entry: SkinEntryInput) => {
+    try {
+      await updateRecord(editRecord!.timestamp, entry);
+      setSnackbar({ open: true, message: '更新しました', severity: 'success' });
+      setEditRecord(null);
+      onRefetch();
+    } catch {
+      setSnackbar({ open: true, message: '更新に失敗しました', severity: 'error' });
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteRecord(deleteTarget!.timestamp);
+      setSnackbar({ open: true, message: '削除しました', severity: 'success' });
+      setDeleteTarget(null);
+      onRefetch();
+    } catch {
+      setSnackbar({ open: true, message: '削除に失敗しました', severity: 'error' });
+    }
+  };
 
   return (
     <>
@@ -94,47 +237,37 @@ function NormalizedTable({ records }: { records: NormalizedRecord[] }) {
               <TableCell align="center">飲酒</TableCell>
               <TableCell>睡眠</TableCell>
               <TableCell>メモ</TableCell>
+              <TableCell align="center">操作</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {paginated.map((r) => (
               <TableRow key={r.id} hover>
                 <TableCell sx={{ whiteSpace: 'nowrap', fontSize: 12 }}>
-                  {new Date(r.timestamp).toLocaleString('ja-JP', {
-                    month: 'short',
-                    day: 'numeric',
-                    hour: '2-digit',
-                    minute: '2-digit',
-                  })}
+                  {new Date(r.timestamp).toLocaleString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                 </TableCell>
-                <TableCell>
-                  <MetricsCell metrics={r.forehead} />
-                </TableCell>
-                <TableCell>
-                  <MetricsCell metrics={r.cheek} />
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption">{r.cosmetics.toner || '—'}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption">{r.cosmetics.essence || '—'}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption">{r.cosmetics.lotion || '—'}</Typography>
-                </TableCell>
-                <TableCell align="center">
-                  <BoolIcon value={r.factors.businessTrip} />
-                </TableCell>
-                <TableCell align="center">
-                  <BoolIcon value={r.factors.alcohol} />
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption">{r.factors.sleepHours}h</Typography>
-                </TableCell>
+                <TableCell><MetricsCell metrics={r.forehead} /></TableCell>
+                <TableCell><MetricsCell metrics={r.cheek} /></TableCell>
+                <TableCell><Typography variant="caption">{r.cosmetics.toner || '—'}</Typography></TableCell>
+                <TableCell><Typography variant="caption">{r.cosmetics.essence || '—'}</Typography></TableCell>
+                <TableCell><Typography variant="caption">{r.cosmetics.lotion || '—'}</Typography></TableCell>
+                <TableCell align="center"><BoolIcon value={r.factors.businessTrip} /></TableCell>
+                <TableCell align="center"><BoolIcon value={r.factors.alcohol} /></TableCell>
+                <TableCell><Typography variant="caption">{r.factors.sleepHours}h</Typography></TableCell>
                 <TableCell sx={{ maxWidth: 120 }}>
-                  <Typography variant="caption" noWrap>
-                    {r.factors.notes || '—'}
-                  </Typography>
+                  <Typography variant="caption" noWrap>{r.factors.notes || '—'}</Typography>
+                </TableCell>
+                <TableCell align="center" sx={{ whiteSpace: 'nowrap' }}>
+                  <Tooltip title="編集">
+                    <IconButton size="small" onClick={() => setEditRecord(r)}>
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="削除">
+                    <IconButton size="small" color="error" onClick={() => setDeleteTarget(r)}>
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
                 </TableCell>
               </TableRow>
             ))}
@@ -147,46 +280,62 @@ function NormalizedTable({ records }: { records: NormalizedRecord[] }) {
         page={page}
         onPageChange={(_, p) => setPage(p)}
         rowsPerPage={rowsPerPage}
-        onRowsPerPageChange={(e) => {
-          setRowsPerPage(parseInt(e.target.value, 10));
-          setPage(0);
-        }}
+        onRowsPerPageChange={(e) => { setRowsPerPage(parseInt(e.target.value, 10)); setPage(0); }}
         rowsPerPageOptions={[5, 10, 25]}
         labelRowsPerPage="表示件数:"
       />
+
+      {editRecord && (
+        <EditDialog record={editRecord} onClose={() => setEditRecord(null)} onSave={handleSave} />
+      )}
+
+      {/* 削除確認ダイアログ */}
+      <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>記録を削除しますか？</DialogTitle>
+        <DialogContent>
+          <Typography>
+            {deleteTarget && new Date(deleteTarget.timestamp).toLocaleString('ja-JP')} の記録を削除します。この操作は元に戻せません。
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)}>キャンセル</Button>
+          <Button variant="contained" color="error" onClick={handleDelete}>削除</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={3000}
+        onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={snackbar.severity} variant="filled">{snackbar.message}</Alert>
+      </Snackbar>
     </>
   );
 }
 
-// データセット別サマリー
 function DatasetSummary({ records }: { records: NormalizedRecord[] }) {
   if (records.length === 0) {
     return <Typography color="text.secondary">データがありません</Typography>;
   }
 
   const latest = records[records.length - 1];
-
   const avgMetric = (key: keyof NormalizedRecord['forehead'], area: 'forehead' | 'cheek') =>
-    (records.reduce((s, r) => s + r[area][key], 0) / records.length).toFixed(2);
+    (records.reduce((s, r) => s + r[area][key], 0) / records.length).toFixed(1);
 
   return (
     <Box>
       <Typography variant="subtitle2" gutterBottom>
         データセット概要（全 {records.length} 件）
       </Typography>
-
       <Box display="flex" gap={4} flexWrap="wrap" mt={2}>
-        {/* 肌状態データセット */}
         <Box flex={1} minWidth={200}>
-          <Typography variant="caption" color="text.secondary" fontWeight={600}>
-            肌状態データセット
-          </Typography>
+          <Typography variant="caption" color="text.secondary" fontWeight={600}>肌状態データセット</Typography>
           <Box mt={1}>
-            {(['tone', 'moisture', 'oil', 'elasticity'] as const).map((key) => (
+            {(Object.keys(METRIC_LABELS) as Array<keyof NormalizedRecord['forehead']>).map((key) => (
               <Box key={key} display="flex" justifyContent="space-between" mb={0.5}>
-                <Typography variant="caption">
-                  {key === 'tone' ? '白さ' : key === 'moisture' ? '水分' : key === 'oil' ? '油分' : '弾力'} (平均)
-                </Typography>
+                <Typography variant="caption">{METRIC_LABELS[key]}（平均）</Typography>
                 <Box display="flex" gap={1}>
                   <ScoreChip value={parseFloat(avgMetric(key, 'forehead'))} />
                   <ScoreChip value={parseFloat(avgMetric(key, 'cheek'))} />
@@ -195,34 +344,20 @@ function DatasetSummary({ records }: { records: NormalizedRecord[] }) {
             ))}
           </Box>
         </Box>
-
-        {/* 使用化粧品データセット */}
         <Box flex={1} minWidth={200}>
-          <Typography variant="caption" color="text.secondary" fontWeight={600}>
-            使用化粧品データセット（最新）
-          </Typography>
+          <Typography variant="caption" color="text.secondary" fontWeight={600}>使用化粧品データセット（最新）</Typography>
           <Box mt={1}>
             <Typography variant="body2">化粧水: {latest.cosmetics.toner || '未使用'}</Typography>
             <Typography variant="body2">美容液: {latest.cosmetics.essence || '未使用'}</Typography>
             <Typography variant="body2">乳液: {latest.cosmetics.lotion || '未使用'}</Typography>
           </Box>
         </Box>
-
-        {/* 外部要因データセット */}
         <Box flex={1} minWidth={200}>
-          <Typography variant="caption" color="text.secondary" fontWeight={600}>
-            外部要因データセット（統計）
-          </Typography>
+          <Typography variant="caption" color="text.secondary" fontWeight={600}>外部要因データセット（統計）</Typography>
           <Box mt={1}>
-            <Typography variant="body2">
-              出張率: {((records.filter((r) => r.factors.businessTrip).length / records.length) * 100).toFixed(0)}%
-            </Typography>
-            <Typography variant="body2">
-              飲酒率: {((records.filter((r) => r.factors.alcohol).length / records.length) * 100).toFixed(0)}%
-            </Typography>
-            <Typography variant="body2">
-              平均睡眠: {(records.reduce((s, r) => s + r.factors.sleepHours, 0) / records.length).toFixed(1)}時間
-            </Typography>
+            <Typography variant="body2">出張率: {((records.filter((r) => r.factors.businessTrip).length / records.length) * 100).toFixed(0)}%</Typography>
+            <Typography variant="body2">飲酒率: {((records.filter((r) => r.factors.alcohol).length / records.length) * 100).toFixed(0)}%</Typography>
+            <Typography variant="body2">平均睡眠: {(records.reduce((s, r) => s + r.factors.sleepHours, 0) / records.length).toFixed(1)}時間</Typography>
           </Box>
         </Box>
       </Box>
@@ -237,47 +372,33 @@ function handleCsvDownload() {
 }
 
 export default function DataTable() {
-  const { records, loading, error } = useSkinData('all');
+  const { records, loading, error, refetch } = useSkinData('all');
   const [tab, setTab] = useState(0);
 
   return (
     <Box>
       <Box display="flex" alignItems="center" justifyContent="space-between" mb={1} flexWrap="wrap" gap={1}>
-        <Typography variant="h5" fontWeight={700}>
-          データビュー
-        </Typography>
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<DownloadIcon />}
-          onClick={handleCsvDownload}
-        >
+        <Typography variant="h5" fontWeight={700}>データビュー</Typography>
+        <Button variant="outlined" size="small" startIcon={<DownloadIcon />} onClick={handleCsvDownload}>
           CSV ダウンロード
         </Button>
       </Box>
       <Typography variant="body2" color="text.secondary" mb={3}>
-        記録したデータを確認・CSV形式でダウンロードできます
+        記録したデータを確認・編集・削除できます
       </Typography>
 
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
       {loading ? (
-        <Box display="flex" justifyContent="center" py={8}>
-          <CircularProgress />
-        </Box>
+        <Box display="flex" justifyContent="center" py={8}><CircularProgress /></Box>
       ) : (
         <Card elevation={0}>
           <CardContent>
-            <Tabs
-              value={tab}
-              onChange={(_, v) => setTab(v)}
-              sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
-            >
+            <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}>
               <Tab label="正規化済みデータ一覧" />
               <Tab label="データセット概要" />
             </Tabs>
-
-            {tab === 0 && <NormalizedTable records={records} />}
+            {tab === 0 && <NormalizedTable records={records} onRefetch={refetch} />}
             {tab === 1 && <DatasetSummary records={records} />}
           </CardContent>
         </Card>

--- a/packages/frontend/src/components/InputForm/index.tsx
+++ b/packages/frontend/src/components/InputForm/index.tsx
@@ -114,7 +114,7 @@ export default function InputForm() {
 
         {/* おでこ */}
         <Grid item xs={12} md={6}>
-          <Card elevation={2}>
+          <Card elevation={0}>
             <CardContent>
               <SkinMetricsInput label="おでこ" value={forehead} onChange={setForehead} />
             </CardContent>
@@ -123,7 +123,7 @@ export default function InputForm() {
 
         {/* ほお */}
         <Grid item xs={12} md={6}>
-          <Card elevation={2}>
+          <Card elevation={0}>
             <CardContent>
               <SkinMetricsInput label="ほお" value={cheek} onChange={setCheek} />
             </CardContent>
@@ -132,7 +132,7 @@ export default function InputForm() {
 
         {/* 使用化粧品 */}
         <Grid item xs={12}>
-          <Card elevation={2}>
+          <Card elevation={0}>
             <CardContent>
               <CosmeticsSelector value={cosmetics} master={master} onChange={setCosmetics} />
             </CardContent>
@@ -141,7 +141,7 @@ export default function InputForm() {
 
         {/* ライフログ */}
         <Grid item xs={12}>
-          <Card elevation={2}>
+          <Card elevation={0}>
             <CardContent>
               <ExternalFactorsInput value={factors} onChange={setFactors} />
             </CardContent>

--- a/packages/frontend/src/constants.ts
+++ b/packages/frontend/src/constants.ts
@@ -1,0 +1,29 @@
+// ============================================================
+// アプリ共通定数
+// ============================================================
+
+/** 肌指標スケール最大値 */
+export const SCALE_MAX = 100;
+
+/** 肌指標ラベル */
+export const METRIC_LABELS: Record<string, string> = {
+  tone: '肌色',
+  moisture: '水分量',
+  oil: '油分量',
+  elasticity: '弾性力',
+};
+
+/** 肌指標カラー */
+export const METRIC_COLORS: Record<string, string> = {
+  tone: '#e91e63',
+  moisture: '#2196f3',
+  oil: '#ff9800',
+  elasticity: '#4caf50',
+};
+
+/** スコア値から MUI color を返す（0〜100スケール） */
+export function getScoreColor(value: number): 'success' | 'warning' | 'error' {
+  if (value >= 70) return 'success';
+  if (value >= 40) return 'warning';
+  return 'error';
+}

--- a/packages/frontend/src/hooks/useSkinData.ts
+++ b/packages/frontend/src/hooks/useSkinData.ts
@@ -68,7 +68,23 @@ export async function submitEntry(entry: SkinEntryInput): Promise<void> {
     body: JSON.stringify(entry),
   });
   const json: ApiResponse<null> = await res.json();
-  if (!json.success) {
-    throw new Error(json.error ?? '保存に失敗しました');
-  }
+  if (!json.success) throw new Error(json.error ?? '保存に失敗しました');
+}
+
+export async function updateRecord(timestamp: string, entry: SkinEntryInput): Promise<void> {
+  const res = await fetch(`${API_BASE}/records/${encodeURIComponent(timestamp)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(entry),
+  });
+  const json: ApiResponse<null> = await res.json();
+  if (!json.success) throw new Error(json.error ?? '更新に失敗しました');
+}
+
+export async function deleteRecord(timestamp: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/records/${encodeURIComponent(timestamp)}`, {
+    method: 'DELETE',
+  });
+  const json: ApiResponse<null> = await res.json();
+  if (!json.success) throw new Error(json.error ?? '削除に失敗しました');
 }


### PR DESCRIPTION
## Why
スケール変更（1〜10 → 0〜100）に伴う表示修正が未対応で数値・色分け・ラベルが旧基準のまま残っていた。また、過去の記録を修正・削除する手段がなく、データが蓄積されても化粧品や外部要因と肌状態の関係を分析できない状態だった。加えて、画面間でカードのデザインが不統一で、化粧品マスタの削除が1クリックで実行されてしまう問題があった。

resolves #14
resolves #15
resolves #16
resolves #17
resolves #18

## What
- スケール・ラベルの全面修正と定数集約（リファクタリング）
- 記録の編集・削除機能の追加
- 化粧品別・外部要因別の分析グラフ追加
- 全画面のカードデザイン統一
- 化粧品マスタの削除を編集中のみ表示・確認ダイアログ化

## How
- `src/constants.ts` を新設し `SCALE_MAX`・`METRIC_LABELS`・`METRIC_COLORS`・`getScoreColor` を集約
- Dashboard サマリーカード・TrendChart・SkinRadarChart・DataTable の表示基準を 0〜100 に統一
- `CsvRepository` に `updateRow` / `deleteRow` を追加、`AppController` に `PUT/DELETE /api/records/:id` を追加
- DataTable に編集ダイアログ（スライダー）と削除確認ダイアログを追加
- `CosmeticsChart.tsx` を新規追加（化粧水/美容液/乳液×部位別 平均スコア棒グラフ）
- `FactorsChart.tsx` を新規追加（睡眠時間帯別・飲酒/出張あり/なし比較棒グラフ）
- ダッシュボードタブに「化粧品比較」「外部要因分析」を追加
- `DataProcessor.clampScore` を 0〜100 スケールに修正
- Dashboard・InputForm の `elevation={2}` を削除しテーマ（elevation=0・border）に統一
- 化粧品マスタの削除ボタンを編集行にのみ表示し、確認ダイアログを追加

## Test
- ダッシュボードのサマリーカードが「/ 100」表示で色分けが正しく動作すること
- DataTable で記録を編集・削除でき、CSV に即時反映されること
- ダッシュボードの「化粧品比較」「外部要因分析」タブでグラフが表示されること
- 全画面（ダッシュボード・記録フォーム・データビュー・化粧品マスタ）のカードデザインが統一されていること
- 化粧品マスタで編集ボタンを押したときのみ削除ボタンが表示されること
- 削除ボタン押下で確認ダイアログが表示され、「削除」を押すまで実行されないこと