### PR TITLE
[feat] add: Milestone 6 — SNS出力強化（日次/週次・テーマ・6種カード・通知）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ packages/backend/data/cosmetics_master.json
 
 # package-lock.json（npm workspaces ではルートのみ管理）
 package-lock.json
+
+# Claude Code ワークツリー（エージェント用一時ディレクトリ）
+.claude/worktrees/

--- a/packages/frontend/src/components/SnsPage/BeforeAfterCard.tsx
+++ b/packages/frontend/src/components/SnsPage/BeforeAfterCard.tsx
@@ -1,0 +1,149 @@
+import { useRef, useState } from 'react';
+import { Box, Typography, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { NormalizedRecord } from '../../types';
+import { CardTheme, CardSize, CARD_THEMES } from '../../constants';
+import { recordHealthScore } from '../../utils/metrics';
+import { formatMonthDay } from '../../utils/format';
+import ChartExportButton from '../shared/ChartExportButton';
+
+interface Props {
+  records: NormalizedRecord[];
+  theme: CardTheme;
+  size: CardSize;
+}
+
+type Period = '1w' | '1m' | '3m';
+
+const PERIOD_DAYS: Record<Period, number> = { '1w': 7, '1m': 30, '3m': 90 };
+const PERIOD_LABELS: Record<Period, string> = { '1w': '1週間', '1m': '1ヶ月', '3m': '3ヶ月' };
+
+export default function BeforeAfterCard({ records, theme, size: _size }: Props) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [period, setPeriod] = useState<Period>('1m');
+  const t = CARD_THEMES[theme];
+
+  if (records.length < 2) {
+    return (
+      <Box sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+        <Typography variant="body2">比較に必要なデータが不足しています</Typography>
+      </Box>
+    );
+  }
+
+  const days = PERIOD_DAYS[period];
+  const now = new Date();
+  const cutoff = new Date(now);
+  cutoff.setDate(now.getDate() - days);
+
+  const filtered = records.filter((r) => new Date(r.timestamp) >= cutoff);
+  const sorted = (filtered.length >= 2 ? filtered : [...records])
+    .slice()
+    .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+  const first = sorted[0];
+  const latest = sorted[sorted.length - 1];
+
+  const beforeScore = recordHealthScore(first);
+  const afterScore = recordHealthScore(latest);
+  const delta = afterScore - beforeScore;
+  const percent = beforeScore > 0 ? Math.round((delta / beforeScore) * 100) : 0;
+
+  const firstDate = new Date(first.timestamp);
+  const latestDate = new Date(latest.timestamp);
+  const diffDays = Math.round((latestDate.getTime() - firstDate.getTime()) / (1000 * 60 * 60 * 24));
+
+  const metricDeltas = [
+    { label: '肌色(おでこ)',   delta: latest.forehead.tone       - first.forehead.tone },
+    { label: '水分量(おでこ)', delta: latest.forehead.moisture   - first.forehead.moisture },
+    { label: '油分量(おでこ)', delta: latest.forehead.oil        - first.forehead.oil },
+    { label: '弾性力(おでこ)', delta: latest.forehead.elasticity - first.forehead.elasticity },
+    { label: '肌色(ほお)',     delta: latest.cheek.tone          - first.cheek.tone },
+    { label: '水分量(ほお)',   delta: latest.cheek.moisture      - first.cheek.moisture },
+    { label: '油分量(ほお)',   delta: latest.cheek.oil           - first.cheek.oil },
+    { label: '弾性力(ほお)',   delta: latest.cheek.elasticity    - first.cheek.elasticity },
+  ];
+  const best = metricDeltas.reduce((a, b) => b.delta > a.delta ? b : a);
+
+  const catchCopy = delta > 0
+    ? `${diffDays}日間で${Math.abs(percent)}%改善！${best.label}が+${best.delta.toFixed(0)}点UP`
+    : delta < 0
+    ? `${diffDays}日間で変化あり。継続ケアが大切です`
+    : `${diffDays}日間スコアを維持中！`;
+
+  return (
+    <Box>
+      <Box display="flex" alignItems="center" justifyContent="space-between" mb={0.5}>
+        <ToggleButtonGroup
+          size="small"
+          value={period}
+          exclusive
+          onChange={(_, v) => v && setPeriod(v as Period)}
+        >
+          {(Object.keys(PERIOD_DAYS) as Period[]).map((p) => (
+            <ToggleButton key={p} value={p} sx={{ fontSize: 11, px: 1, py: 0.3 }}>
+              {PERIOD_LABELS[p]}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+        <ChartExportButton targetRef={cardRef} filename="before-after" />
+      </Box>
+      <Box
+        ref={cardRef}
+        sx={{
+          background: t.background,
+          borderRadius: 3,
+          border: `1px solid ${t.borderColor}`,
+          overflow: 'hidden',
+        }}
+      >
+        <Box sx={{ px: 3, pt: 2, pb: 1, textAlign: 'center' }}>
+          <Typography sx={{ fontSize: 13, color: t.primaryColor, fontWeight: 700 }}>
+            {catchCopy}
+          </Typography>
+        </Box>
+        <Box display="flex">
+          <Box
+            sx={{
+              flex: 1,
+              p: 2.5,
+              bgcolor: 'rgba(0,0,0,0.1)',
+              borderRight: `1px solid ${t.borderColor}`,
+              textAlign: 'center',
+            }}
+          >
+            <Typography sx={{ fontSize: 10, color: t.subTextColor, letterSpacing: 1, mb: 0.5 }}>BEFORE</Typography>
+            <Typography sx={{ fontSize: 11, color: t.subTextColor, mb: 1 }}>
+              {formatMonthDay(first.timestamp)}
+            </Typography>
+            <Typography sx={{ fontSize: '2.2rem', fontWeight: 900, color: t.subTextColor, lineHeight: 1 }}>
+              {beforeScore.toFixed(1)}
+            </Typography>
+          </Box>
+          <Box
+            sx={{
+              flex: 1,
+              p: 2.5,
+              textAlign: 'center',
+            }}
+          >
+            <Typography sx={{ fontSize: 10, color: t.primaryColor, letterSpacing: 1, fontWeight: 700, mb: 0.5 }}>AFTER</Typography>
+            <Typography sx={{ fontSize: 11, color: t.subTextColor, mb: 1 }}>
+              {formatMonthDay(latest.timestamp)}
+            </Typography>
+            <Typography sx={{ fontSize: '2.2rem', fontWeight: 900, color: t.primaryColor, lineHeight: 1 }}>
+              {afterScore.toFixed(1)}
+            </Typography>
+            <Typography sx={{
+              fontSize: 12,
+              fontWeight: 700,
+              color: delta > 0 ? '#4caf50' : delta < 0 ? '#f44336' : t.subTextColor,
+              mt: 0.5,
+            }}>
+              {delta > 0 ? '+' : ''}{delta.toFixed(1)}点
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/frontend/src/components/SnsPage/BeforeAfterCard.tsx
+++ b/packages/frontend/src/components/SnsPage/BeforeAfterCard.tsx
@@ -36,7 +36,8 @@ export default function BeforeAfterCard({ records, theme, size: _size }: Props) 
   cutoff.setDate(now.getDate() - days);
 
   const filtered = records.filter((r) => new Date(r.timestamp) >= cutoff);
-  const sorted = (filtered.length >= 2 ? filtered : [...records])
+  const hasSufficientFiltered = filtered.length >= 2;
+  const sorted = (hasSufficientFiltered ? filtered : [...records])
     .slice()
     .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
 
@@ -97,6 +98,11 @@ export default function BeforeAfterCard({ records, theme, size: _size }: Props) 
         }}
       >
         <Box sx={{ px: 3, pt: 2, pb: 1, textAlign: 'center' }}>
+          {!hasSufficientFiltered && (
+            <Typography sx={{ fontSize: 10, color: t.subTextColor, mb: 1 }}>
+              ※ 選択期間内のデータが不足のため全期間で比較
+            </Typography>
+          )}
           <Typography sx={{ fontSize: 13, color: t.primaryColor, fontWeight: 700 }}>
             {catchCopy}
           </Typography>

--- a/packages/frontend/src/components/SnsPage/CompactCalendarHeatmap.tsx
+++ b/packages/frontend/src/components/SnsPage/CompactCalendarHeatmap.tsx
@@ -1,0 +1,170 @@
+import { useRef } from 'react';
+import { Box, Tooltip, Typography } from '@mui/material';
+import { NormalizedRecord } from '../../types';
+import { CardTheme, CardSize, CARD_THEMES } from '../../constants';
+import { buildScoreByDate } from '../../utils/metrics';
+import { formatFullDate } from '../../utils/format';
+import ChartExportButton from '../shared/ChartExportButton';
+
+interface Props {
+  records: NormalizedRecord[];
+  theme: CardTheme;
+  size: CardSize;
+}
+
+const WEEKDAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
+function scoreToColor(score: number, theme: CardTheme): string {
+  if (theme === 'luxury') {
+    if (score >= 75) return '#FFD700';
+    if (score >= 55) return '#B8860B';
+    if (score >= 35) return '#4A3A00';
+    return '#2A2A2A';
+  }
+  if (theme === 'minimal') {
+    if (score >= 75) return '#424242';
+    if (score >= 55) return '#757575';
+    if (score >= 35) return '#BDBDBD';
+    return '#EEEEEE';
+  }
+  if (score >= 75) return '#ad1457';
+  if (score >= 55) return '#e91e63';
+  if (score >= 35) return '#f48fb1';
+  return '#fce4ec';
+}
+
+function buildDays(daysCount: number): string[] {
+  const today = new Date();
+  const result: string[] = [];
+  for (let i = daysCount - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    result.push(d.toISOString().slice(0, 10));
+  }
+  return result;
+}
+
+function groupByMonth(days: string[]): { month: string; dates: string[] }[] {
+  const map = new Map<string, string[]>();
+  for (const d of days) {
+    const month = d.slice(0, 7);
+    if (!map.has(month)) map.set(month, []);
+    map.get(month)!.push(d);
+  }
+  return Array.from(map.entries()).map(([month, dates]) => ({ month, dates }));
+}
+
+export default function CompactCalendarHeatmap({ records, theme, size: _size }: Props) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const t = CARD_THEMES[theme];
+  const scoreByDate = buildScoreByDate(records);
+
+  const allScores = Array.from(scoreByDate.entries());
+  const bestDate = allScores.length > 0
+    ? allScores.reduce((a, b) => b[1] > a[1] ? b : a)[0]
+    : null;
+  const worstDate = allScores.length > 0
+    ? allScores.reduce((a, b) => b[1] < a[1] ? b : a)[0]
+    : null;
+
+  const days = buildDays(90);
+  const months = groupByMonth(days);
+  const cellSize = 18;
+  const cellGap = 3;
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="flex-end" mb={0.5}>
+        <ChartExportButton targetRef={cardRef} filename="compact-calendar" />
+      </Box>
+      <Box
+        ref={cardRef}
+        sx={{
+          background: t.background,
+          borderRadius: 3,
+          p: 2,
+          border: `1px solid ${t.borderColor}`,
+          overflowX: 'auto',
+        }}
+      >
+        <Typography sx={{ fontSize: 12, color: t.subTextColor, mb: 1.5 }}>直近3ヶ月の肌記録</Typography>
+        <Box display="flex" flexDirection="column" gap={2}>
+          {months.map(({ month, dates }) => {
+            const [y, m] = month.split('-');
+            const monthLabel = `${parseInt(y)}年${parseInt(m)}月`;
+            const firstDate = new Date(dates[0]);
+            const leadingBlanks = firstDate.getDay();
+            const totalCols = Math.ceil((leadingBlanks + dates.length) / 7);
+
+            return (
+              <Box key={month}>
+                <Typography sx={{ fontSize: 11, color: t.subTextColor, mb: 0.5, fontWeight: 700 }}>
+                  {monthLabel}
+                </Typography>
+                <Box display="flex" gap={0}>
+                  <Box sx={{ display: 'flex', flexDirection: 'column', mr: `${cellGap}px` }}>
+                    {WEEKDAY_LABELS.map((wl, i) => (
+                      <Box key={wl} sx={{ height: cellSize + cellGap, display: 'flex', alignItems: 'center' }}>
+                        {i % 2 === 0 && (
+                          <Typography sx={{ fontSize: 9, color: t.subTextColor, width: cellSize - 4, textAlign: 'center' }}>
+                            {wl}
+                          </Typography>
+                        )}
+                      </Box>
+                    ))}
+                  </Box>
+                  <Box sx={{ display: 'flex', gap: `${cellGap}px` }}>
+                    {Array.from({ length: totalCols }, (_, col) => (
+                      <Box key={col} sx={{ display: 'flex', flexDirection: 'column', gap: `${cellGap}px` }}>
+                        {Array.from({ length: 7 }, (_, row) => {
+                          const idx = col * 7 + row - leadingBlanks;
+                          if (idx < 0 || idx >= dates.length) {
+                            return <Box key={row} sx={{ width: cellSize, height: cellSize }} />;
+                          }
+                          const date = dates[idx];
+                          const score = scoreByDate.get(date);
+                          const bgColor = score !== undefined
+                            ? scoreToColor(score, theme)
+                            : theme === 'luxury' ? '#1a1a1a' : '#f0f0f0';
+                          const isBest = date === bestDate;
+                          const isWorst = date === worstDate;
+
+                          return (
+                            <Tooltip
+                              key={row}
+                              title={score !== undefined ? `${formatFullDate(date)}: ${score.toFixed(1)}` : formatFullDate(date)}
+                              arrow
+                            >
+                              <Box
+                                sx={{
+                                  width: cellSize,
+                                  height: cellSize,
+                                  borderRadius: '3px',
+                                  bgcolor: bgColor,
+                                  border: `1px solid ${score !== undefined ? 'rgba(0,0,0,0.12)' : 'transparent'}`,
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  justifyContent: 'center',
+                                  fontSize: 10,
+                                  cursor: score !== undefined ? 'pointer' : 'default',
+                                  transition: 'transform 0.1s',
+                                  '&:hover': score !== undefined ? { transform: 'scale(1.3)' } : {},
+                                }}
+                              >
+                                {isBest ? '👑' : isWorst ? '💧' : ''}
+                              </Box>
+                            </Tooltip>
+                          );
+                        })}
+                      </Box>
+                    ))}
+                  </Box>
+                </Box>
+              </Box>
+            );
+          })}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/frontend/src/components/SnsPage/CompactCalendarHeatmap.tsx
+++ b/packages/frontend/src/components/SnsPage/CompactCalendarHeatmap.tsx
@@ -57,17 +57,13 @@ function groupByMonth(days: string[]): { month: string; dates: string[] }[] {
 export default function CompactCalendarHeatmap({ records, theme, size: _size }: Props) {
   const cardRef = useRef<HTMLDivElement>(null);
   const t = CARD_THEMES[theme];
-  const scoreByDate = buildScoreByDate(records);
-
-  const allScores = Array.from(scoreByDate.entries());
-  const bestDate = allScores.length > 0
-    ? allScores.reduce((a, b) => b[1] > a[1] ? b : a)[0]
-    : null;
-  const worstDate = allScores.length > 0
-    ? allScores.reduce((a, b) => b[1] < a[1] ? b : a)[0]
-    : null;
 
   const days = buildDays(90);
+  const scoreByDate = buildScoreByDate(records);
+  const daysSet = new Set(days);
+  const viewScores = Array.from(scoreByDate.entries()).filter(([d]) => daysSet.has(d));
+  const bestDate = viewScores.length > 0 ? viewScores.reduce((a, b) => b[1] > a[1] ? b : a)[0] : null;
+  const worstDate = viewScores.length > 0 ? viewScores.reduce((a, b) => b[1] < a[1] ? b : a)[0] : null;
   const months = groupByMonth(days);
   const cellSize = 18;
   const cellGap = 3;

--- a/packages/frontend/src/components/SnsPage/CosmeticsRankingCard.tsx
+++ b/packages/frontend/src/components/SnsPage/CosmeticsRankingCard.tsx
@@ -81,16 +81,21 @@ export default function CosmeticsRankingCard({ records, theme, size: _size }: Pr
           {COSMETIC_FIELD_LABELS[category]} ランキング
         </Typography>
 
-        {ranked.length < 3 ? (
+        {ranked.length === 0 && (
           <Box textAlign="center" py={3}>
             <Typography sx={{ fontSize: 14, color: t.subTextColor }}>
-              データ不足（各5件以上必要）
-            </Typography>
-            <Typography sx={{ fontSize: 12, color: t.subTextColor, mt: 0.5 }}>
-              現在 {ranked.length} 件のコスメが対象
+              データ不足（各コスメ5件以上の記録が必要）
             </Typography>
           </Box>
-        ) : (
+        )}
+        {ranked.length > 0 && ranked.length < 3 && (
+          <Box textAlign="center" py={3}>
+            <Typography sx={{ fontSize: 14, color: t.subTextColor }}>
+              ランキング表示には3種類以上必要です（現在 {ranked.length} 種類）
+            </Typography>
+          </Box>
+        )}
+        {ranked.length >= 3 && (
           <Box display="flex" alignItems="flex-end" justifyContent="center" gap={2}>
             {podiumOrder.map((item, podiumIdx) => {
               const rankIdx = podiumIndexMap[podiumIdx];

--- a/packages/frontend/src/components/SnsPage/CosmeticsRankingCard.tsx
+++ b/packages/frontend/src/components/SnsPage/CosmeticsRankingCard.tsx
@@ -1,0 +1,157 @@
+import { useRef, useState } from 'react';
+import { Box, Typography, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { NormalizedRecord, CosmeticsMaster } from '../../types';
+import { CardTheme, CardSize, CARD_THEMES, COSMETIC_FIELD_LABELS } from '../../constants';
+import { recordHealthScore } from '../../utils/metrics';
+import ChartExportButton from '../shared/ChartExportButton';
+
+interface Props {
+  records: NormalizedRecord[];
+  master: CosmeticsMaster;
+  theme: CardTheme;
+  size: CardSize;
+}
+
+type Category = 'toner' | 'essence' | 'lotion' | 'primer';
+const CATEGORIES: Category[] = ['toner', 'essence', 'lotion', 'primer'];
+
+const RANK_COLORS = ['#FFD700', '#C0C0C0', '#CD7F32'];
+const RANK_SIZES = ['2rem', '1.6rem', '1.4rem'];
+const RANK_LABELS = ['1st', '2nd', '3rd'];
+
+export default function CosmeticsRankingCard({ records, theme, size: _size }: Props) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [category, setCategory] = useState<Category>('toner');
+  const t = CARD_THEMES[theme];
+
+  const allScores = records.map((r) => recordHealthScore(r));
+  const globalAvg = allScores.length > 0 ? allScores.reduce((s, v) => s + v, 0) / allScores.length : 50;
+
+  const cosmeticNames = Array.from(
+    new Set(records.map((r) => r.cosmetics[category]).filter(Boolean))
+  );
+
+  const ranked = cosmeticNames
+    .map((name) => {
+      const usedRecords = records.filter((r) => r.cosmetics[category] === name);
+      const unusedRecords = records.filter((r) => r.cosmetics[category] !== name);
+      if (usedRecords.length < 5) return null;
+      const usedAvg = usedRecords.map((r) => recordHealthScore(r)).reduce((s, v) => s + v, 0) / usedRecords.length;
+      const unusedAvg = unusedRecords.length > 0
+        ? unusedRecords.map((r) => recordHealthScore(r)).reduce((s, v) => s + v, 0) / unusedRecords.length
+        : globalAvg;
+      const contribution = usedAvg - unusedAvg;
+      return { name, contribution, usedCount: usedRecords.length };
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null)
+    .sort((a, b) => b.contribution - a.contribution)
+    .slice(0, 3);
+
+  const podiumOrder = ranked.length >= 3 ? [ranked[1], ranked[0], ranked[2]] : ranked;
+  const podiumIndexMap = ranked.length >= 3 ? [1, 0, 2] : [0];
+
+  return (
+    <Box>
+      <Box display="flex" alignItems="center" justifyContent="space-between" mb={0.5}>
+        <ToggleButtonGroup
+          size="small"
+          value={category}
+          exclusive
+          onChange={(_, v) => v && setCategory(v as Category)}
+        >
+          {CATEGORIES.map((c) => (
+            <ToggleButton key={c} value={c} sx={{ fontSize: 11, px: 1, py: 0.3 }}>
+              {COSMETIC_FIELD_LABELS[c]}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+        <ChartExportButton targetRef={cardRef} filename="cosmetics-ranking" />
+      </Box>
+      <Box
+        ref={cardRef}
+        sx={{
+          background: t.background,
+          borderRadius: 3,
+          p: 3,
+          border: `1px solid ${t.borderColor}`,
+          minHeight: 200,
+        }}
+      >
+        <Typography sx={{ fontSize: 12, color: t.subTextColor, mb: 2, textAlign: 'center' }}>
+          {COSMETIC_FIELD_LABELS[category]} ランキング
+        </Typography>
+
+        {ranked.length < 3 ? (
+          <Box textAlign="center" py={3}>
+            <Typography sx={{ fontSize: 14, color: t.subTextColor }}>
+              データ不足（各5件以上必要）
+            </Typography>
+            <Typography sx={{ fontSize: 12, color: t.subTextColor, mt: 0.5 }}>
+              現在 {ranked.length} 件のコスメが対象
+            </Typography>
+          </Box>
+        ) : (
+          <Box display="flex" alignItems="flex-end" justifyContent="center" gap={2}>
+            {podiumOrder.map((item, podiumIdx) => {
+              const rankIdx = podiumIndexMap[podiumIdx];
+              const color = RANK_COLORS[rankIdx];
+              const fontSize = RANK_SIZES[rankIdx];
+              const label = RANK_LABELS[rankIdx];
+              const podiumHeight = rankIdx === 0 ? 80 : rankIdx === 1 ? 60 : 50;
+
+              return (
+                <Box
+                  key={item.name}
+                  display="flex"
+                  flexDirection="column"
+                  alignItems="center"
+                  sx={{ flex: 1 }}
+                >
+                  <Typography sx={{ fontSize: 10, color: t.subTextColor, mb: 0.5, textAlign: 'center' }}>
+                    {label}
+                  </Typography>
+                  <Typography sx={{ fontSize: 14, color, fontWeight: 900 }}>{label.replace('st', '').replace('nd', '').replace('rd', '')}</Typography>
+                  <Box
+                    sx={{
+                      width: '100%',
+                      height: podiumHeight,
+                      bgcolor: color,
+                      borderRadius: '8px 8px 0 0',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      p: 1,
+                    }}
+                  >
+                    <Typography sx={{ fontSize: fontSize, fontWeight: 900, color: '#fff', lineHeight: 1 }}>
+                      {rankIdx + 1}
+                    </Typography>
+                  </Box>
+                  <Box
+                    sx={{
+                      width: '100%',
+                      bgcolor: 'rgba(255,255,255,0.15)',
+                      border: `1px solid ${t.borderColor}`,
+                      borderTop: 'none',
+                      borderRadius: '0 0 8px 8px',
+                      p: 1,
+                      textAlign: 'center',
+                    }}
+                  >
+                    <Typography sx={{ fontSize: 11, color: t.textColor, fontWeight: 700, wordBreak: 'break-all', lineHeight: 1.3 }}>
+                      {item.name}
+                    </Typography>
+                    <Typography sx={{ fontSize: 12, color: item.contribution >= 0 ? '#4caf50' : '#f44336', fontWeight: 700, mt: 0.3 }}>
+                      {item.contribution >= 0 ? '+' : ''}{item.contribution.toFixed(1)}点
+                    </Typography>
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/packages/frontend/src/components/SnsPage/FactorsInsightCard.tsx
+++ b/packages/frontend/src/components/SnsPage/FactorsInsightCard.tsx
@@ -1,0 +1,133 @@
+import { useRef } from 'react';
+import { Box, LinearProgress, Typography } from '@mui/material';
+import HotelIcon from '@mui/icons-material/Hotel';
+import LocalBarIcon from '@mui/icons-material/LocalBar';
+import WorkIcon from '@mui/icons-material/Work';
+import { NormalizedRecord } from '../../types';
+import { CardTheme, CardSize, CARD_THEMES } from '../../constants';
+import { recordHealthScore } from '../../utils/metrics';
+import ChartExportButton from '../shared/ChartExportButton';
+
+interface Props {
+  records: NormalizedRecord[];
+  theme: CardTheme;
+  size: CardSize;
+}
+
+interface Insight {
+  icon: React.ReactNode;
+  label: string;
+  delta: number;
+  usedCount: number;
+}
+
+export default function FactorsInsightCard({ records, theme, size: _size }: Props) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const t = CARD_THEMES[theme];
+
+  function calcDelta(
+    positives: NormalizedRecord[],
+    negatives: NormalizedRecord[],
+  ): number | null {
+    if (positives.length < 5 || negatives.length < 5) return null;
+    const posAvg = positives.map((r) => recordHealthScore(r)).reduce((s, v) => s + v, 0) / positives.length;
+    const negAvg = negatives.map((r) => recordHealthScore(r)).reduce((s, v) => s + v, 0) / negatives.length;
+    return posAvg - negAvg;
+  }
+
+  const sleepGood = records.filter((r) => r.factors.sleepHours >= 7);
+  const sleepBad = records.filter((r) => r.factors.sleepHours < 7 && r.factors.sleepHours > 0);
+  const noAlcohol = records.filter((r) => !r.factors.alcohol);
+  const withAlcohol = records.filter((r) => r.factors.alcohol);
+  const noTrip = records.filter((r) => !r.factors.businessTrip);
+  const withTrip = records.filter((r) => r.factors.businessTrip);
+
+  const candidates: (Insight | null)[] = [
+    (() => {
+      const d = calcDelta(sleepGood, sleepBad);
+      if (d === null) return null;
+      return { icon: <HotelIcon sx={{ fontSize: 16 }} />, label: '睡眠7h以上', delta: d, usedCount: sleepGood.length };
+    })(),
+    (() => {
+      const d = calcDelta(noAlcohol, withAlcohol);
+      if (d === null) return null;
+      return { icon: <LocalBarIcon sx={{ fontSize: 16 }} />, label: '飲酒なし', delta: d, usedCount: noAlcohol.length };
+    })(),
+    (() => {
+      const d = calcDelta(noTrip, withTrip);
+      if (d === null) return null;
+      return { icon: <WorkIcon sx={{ fontSize: 16 }} />, label: '出張なし', delta: d, usedCount: noTrip.length };
+    })(),
+  ];
+
+  const insights = candidates
+    .filter((x): x is Insight => x !== null)
+    .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))
+    .slice(0, 3);
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="flex-end" mb={0.5}>
+        <ChartExportButton targetRef={cardRef} filename="factors-insight" />
+      </Box>
+      <Box
+        ref={cardRef}
+        sx={{
+          background: t.background,
+          borderRadius: 3,
+          p: 3,
+          border: `1px solid ${t.borderColor}`,
+        }}
+      >
+        <Typography sx={{ fontSize: 12, color: t.subTextColor, mb: 2, textAlign: 'center' }}>
+          生活習慣インサイト
+        </Typography>
+
+        {insights.length === 0 ? (
+          <Box textAlign="center" py={2}>
+            <Typography sx={{ fontSize: 14, color: t.subTextColor }}>
+              データ不足（各条件5件以上必要）
+            </Typography>
+          </Box>
+        ) : (
+          <Box display="flex" flexDirection="column" gap={2}>
+            {insights.map((insight) => (
+              <Box key={insight.label}>
+                <Box display="flex" alignItems="center" justifyContent="space-between" mb={0.5}>
+                  <Box display="flex" alignItems="center" gap={0.75}>
+                    <Box sx={{ color: t.primaryColor }}>{insight.icon}</Box>
+                    <Typography sx={{ fontSize: 13, color: t.textColor, fontWeight: 600 }}>
+                      {insight.label}
+                    </Typography>
+                  </Box>
+                  <Typography sx={{
+                    fontSize: 13,
+                    fontWeight: 700,
+                    color: insight.delta >= 0 ? '#4caf50' : '#f44336',
+                  }}>
+                    {insight.delta >= 0 ? '+' : ''}{insight.delta.toFixed(1)}点
+                  </Typography>
+                </Box>
+                <LinearProgress
+                  variant="determinate"
+                  value={Math.min(100, Math.abs(insight.delta) * 2)}
+                  sx={{
+                    height: 8,
+                    borderRadius: 4,
+                    bgcolor: `${t.borderColor}44`,
+                    '& .MuiLinearProgress-bar': {
+                      bgcolor: insight.delta >= 0 ? '#4caf50' : '#f44336',
+                    },
+                  }}
+                />
+                <Typography sx={{ fontSize: 10, color: t.subTextColor, mt: 0.3 }}>
+                  n={insight.usedCount}件のデータより算出
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/packages/frontend/src/components/SnsPage/WeeklyScoreCard.tsx
+++ b/packages/frontend/src/components/SnsPage/WeeklyScoreCard.tsx
@@ -1,0 +1,106 @@
+import { useRef } from 'react';
+import { Box, LinearProgress, Typography } from '@mui/material';
+import { NormalizedRecord } from '../../types';
+import { CardTheme, CardSize, CARD_THEMES, RANK_CONFIG, getScoreRank } from '../../constants';
+import { recordHealthScore } from '../../utils/metrics';
+import ChartExportButton from '../shared/ChartExportButton';
+
+interface Props {
+  records: NormalizedRecord[];
+  theme: CardTheme;
+  size: CardSize;
+}
+
+const METRIC_ROWS: { label: string; area: 'forehead' | 'cheek'; key: 'tone' | 'moisture' | 'oil' | 'elasticity' }[] = [
+  { label: 'おでこ 肌色',   area: 'forehead', key: 'tone' },
+  { label: 'おでこ 水分量', area: 'forehead', key: 'moisture' },
+  { label: 'おでこ 油分量', area: 'forehead', key: 'oil' },
+  { label: 'おでこ 弾性力', area: 'forehead', key: 'elasticity' },
+  { label: 'ほお 肌色',     area: 'cheek',    key: 'tone' },
+  { label: 'ほお 水分量',   area: 'cheek',    key: 'moisture' },
+  { label: 'ほお 油分量',   area: 'cheek',    key: 'oil' },
+  { label: 'ほお 弾性力',   area: 'cheek',    key: 'elasticity' },
+];
+
+export default function WeeklyScoreCard({ records, theme, size: _size }: Props) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const t = CARD_THEMES[theme];
+
+  const now = new Date();
+  const weekAgo = new Date(now);
+  weekAgo.setDate(now.getDate() - 7);
+
+  const weekRecords = records.filter((r) => {
+    const d = new Date(r.timestamp);
+    return d >= weekAgo && d <= now;
+  });
+
+  if (weekRecords.length === 0) {
+    return (
+      <Box sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+        <Typography variant="body2">直近7日間のデータがありません</Typography>
+      </Box>
+    );
+  }
+
+  const scores = weekRecords.map((r) => recordHealthScore(r));
+  const avgScore = scores.reduce((s, v) => s + v, 0) / scores.length;
+  const rank = getScoreRank(avgScore);
+  const rankConfig = RANK_CONFIG[rank];
+
+  const metricAvgs = METRIC_ROWS.map(({ label, area, key }) => {
+    const avg = weekRecords.reduce((s, r) => s + r[area][key], 0) / weekRecords.length;
+    return { label, avg };
+  });
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="flex-end" mb={0.5}>
+        <ChartExportButton targetRef={cardRef} filename="weekly-score" />
+      </Box>
+      <Box
+        ref={cardRef}
+        sx={{
+          background: t.background,
+          borderRadius: 3,
+          p: 3,
+          border: `1px solid ${t.borderColor}`,
+        }}
+      >
+        <Box textAlign="center" mb={3}>
+          <Typography sx={{ fontSize: 11, color: t.subTextColor }}>週間スコアランク</Typography>
+          <Typography sx={{ fontSize: '4rem', fontWeight: 900, color: rankConfig.color, lineHeight: 1 }}>
+            {rank}
+          </Typography>
+          <Typography sx={{ fontSize: 13, color: rankConfig.color, fontWeight: 700, letterSpacing: 2 }}>
+            {rankConfig.label}
+          </Typography>
+          <Typography sx={{ fontSize: 18, fontWeight: 700, color: t.primaryColor, mt: 0.5 }}>
+            {avgScore.toFixed(1)} / 100
+          </Typography>
+        </Box>
+
+        <Box display="flex" flexDirection="column" gap={1}>
+          {metricAvgs.map(({ label, avg }) => (
+            <Box key={label}>
+              <Box display="flex" justifyContent="space-between" mb={0.3}>
+                <Typography sx={{ fontSize: 11, color: t.subTextColor }}>{label}</Typography>
+                <Typography sx={{ fontSize: 11, fontWeight: 700, color: t.textColor }}>{avg.toFixed(1)}</Typography>
+              </Box>
+              <LinearProgress
+                variant="determinate"
+                value={Math.min(100, avg)}
+                sx={{
+                  height: 6,
+                  borderRadius: 3,
+                  bgcolor: `${t.borderColor}44`,
+                  '& .MuiLinearProgress-bar': { bgcolor: t.primaryColor },
+                }}
+              />
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/frontend/src/components/SnsPage/WeeklyScoreCard.tsx
+++ b/packages/frontend/src/components/SnsPage/WeeklyScoreCard.tsx
@@ -1,9 +1,17 @@
 import { useRef } from 'react';
 import { Box, LinearProgress, Typography } from '@mui/material';
-import { NormalizedRecord } from '../../types';
+import { NormalizedRecord, SkinMetrics } from '../../types';
 import { CardTheme, CardSize, CARD_THEMES, RANK_CONFIG, getScoreRank } from '../../constants';
 import { recordHealthScore } from '../../utils/metrics';
 import ChartExportButton from '../shared/ChartExportButton';
+
+const METRIC_RANGE: Record<keyof SkinMetrics, [number, number]> = {
+  tone: [20, 70], moisture: [30, 50], oil: [30, 50], elasticity: [30, 70],
+};
+function normalizeMetric(value: number, key: keyof SkinMetrics): number {
+  const [min, max] = METRIC_RANGE[key];
+  return Math.min(100, Math.max(0, (value - min) / (max - min) * 100));
+}
 
 interface Props {
   records: NormalizedRecord[];
@@ -50,7 +58,7 @@ export default function WeeklyScoreCard({ records, theme, size: _size }: Props) 
 
   const metricAvgs = METRIC_ROWS.map(({ label, area, key }) => {
     const avg = weekRecords.reduce((s, r) => s + r[area][key], 0) / weekRecords.length;
-    return { label, avg };
+    return { label, avg, key };
   });
 
   return (
@@ -81,7 +89,7 @@ export default function WeeklyScoreCard({ records, theme, size: _size }: Props) 
         </Box>
 
         <Box display="flex" flexDirection="column" gap={1}>
-          {metricAvgs.map(({ label, avg }) => (
+          {metricAvgs.map(({ label, avg, key }) => (
             <Box key={label}>
               <Box display="flex" justifyContent="space-between" mb={0.3}>
                 <Typography sx={{ fontSize: 11, color: t.subTextColor }}>{label}</Typography>
@@ -89,7 +97,7 @@ export default function WeeklyScoreCard({ records, theme, size: _size }: Props) 
               </Box>
               <LinearProgress
                 variant="determinate"
-                value={Math.min(100, avg)}
+                value={normalizeMetric(avg, key)}
                 sx={{
                   height: 6,
                   borderRadius: 3,

--- a/packages/frontend/src/components/SnsPage/WeeklySummaryCard.tsx
+++ b/packages/frontend/src/components/SnsPage/WeeklySummaryCard.tsx
@@ -1,0 +1,140 @@
+import { useRef } from 'react';
+import { Box, Typography } from '@mui/material';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
+import TrendingFlatIcon from '@mui/icons-material/TrendingFlat';
+import { NormalizedRecord } from '../../types';
+import { CardTheme, CardSize, CARD_THEMES } from '../../constants';
+import { recordHealthScore } from '../../utils/metrics';
+import { formatMonthDay } from '../../utils/format';
+import ChartExportButton from '../shared/ChartExportButton';
+
+interface Props {
+  records: NormalizedRecord[];
+  theme: CardTheme;
+  size: CardSize;
+}
+
+export default function WeeklySummaryCard({ records, theme, size }: Props) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const t = CARD_THEMES[theme];
+
+  const now = new Date();
+  const weekAgo = new Date(now);
+  weekAgo.setDate(now.getDate() - 7);
+  const twoWeeksAgo = new Date(now);
+  twoWeeksAgo.setDate(now.getDate() - 14);
+
+  const weekRecords = records.filter((r) => {
+    const d = new Date(r.timestamp);
+    return d >= weekAgo && d <= now;
+  });
+  const prevWeekRecords = records.filter((r) => {
+    const d = new Date(r.timestamp);
+    return d >= twoWeeksAgo && d < weekAgo;
+  });
+
+  if (weekRecords.length === 0) {
+    return (
+      <Box sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+        <Typography variant="body2">直近7日間のデータがありません</Typography>
+      </Box>
+    );
+  }
+
+  const weekScores = weekRecords.map((r) => recordHealthScore(r));
+  const avgScore = weekScores.reduce((s, v) => s + v, 0) / weekScores.length;
+
+  const prevAvg = prevWeekRecords.length > 0
+    ? prevWeekRecords.map((r) => recordHealthScore(r)).reduce((s, v) => s + v, 0) / prevWeekRecords.length
+    : null;
+  const diff = prevAvg !== null ? avgScore - prevAvg : null;
+
+  const bestRecord = weekRecords.reduce((best, r) =>
+    recordHealthScore(r) > recordHealthScore(best) ? r : best
+  );
+  const worstRecord = weekRecords.reduce((worst, r) =>
+    recordHealthScore(r) < recordHealthScore(worst) ? r : worst
+  );
+
+  const startDateLabel = formatMonthDay(weekRecords[0].timestamp);
+  const endDateLabel = formatMonthDay(weekRecords[weekRecords.length - 1].timestamp);
+
+  const aspectRatio = size === 'story' ? '9 / 16' : size === 'wide' ? '16 / 9' : '1 / 1';
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="flex-end" mb={0.5}>
+        <ChartExportButton targetRef={cardRef} filename="weekly-summary" />
+      </Box>
+      <Box
+        ref={cardRef}
+        sx={{
+          background: t.background,
+          borderRadius: 3,
+          p: 3,
+          aspectRatio,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          border: `1px solid ${t.borderColor}`,
+        }}
+      >
+        <Box>
+          <Typography sx={{ fontSize: 11, color: t.subTextColor, fontWeight: t.fontWeight }}>
+            週間サマリー
+          </Typography>
+          <Typography sx={{ fontSize: 13, color: t.subTextColor, mt: 0.5 }}>
+            {startDateLabel} 〜 {endDateLabel}
+          </Typography>
+        </Box>
+
+        <Box textAlign="center">
+          <Typography sx={{ fontSize: 12, color: t.subTextColor }}>週間平均スコア</Typography>
+          <Typography sx={{ fontSize: '3rem', fontWeight: 900, color: t.primaryColor, lineHeight: 1.1 }}>
+            {avgScore.toFixed(1)}
+          </Typography>
+          {diff !== null && (
+            <Box display="flex" alignItems="center" justifyContent="center" gap={0.5} mt={0.5}>
+              {diff > 2 ? (
+                <TrendingUpIcon sx={{ color: '#4caf50', fontSize: 18 }} />
+              ) : diff < -2 ? (
+                <TrendingDownIcon sx={{ color: '#f44336', fontSize: 18 }} />
+              ) : (
+                <TrendingFlatIcon sx={{ color: t.subTextColor, fontSize: 18 }} />
+              )}
+              <Typography sx={{
+                fontSize: 13,
+                fontWeight: 700,
+                color: diff > 2 ? '#4caf50' : diff < -2 ? '#f44336' : t.subTextColor,
+              }}>
+                前週比 {diff > 0 ? '+' : ''}{diff.toFixed(1)}点
+              </Typography>
+            </Box>
+          )}
+        </Box>
+
+        <Box display="flex" gap={2} justifyContent="space-between">
+          <Box sx={{ flex: 1, bgcolor: 'rgba(255,255,255,0.15)', borderRadius: 2, p: 1.5, border: `1px solid ${t.borderColor}` }}>
+            <Typography sx={{ fontSize: 10, color: t.subTextColor }}>最良日 🌟</Typography>
+            <Typography sx={{ fontSize: 12, fontWeight: 700, color: t.textColor, mt: 0.3 }}>
+              {formatMonthDay(bestRecord.timestamp)}
+            </Typography>
+            <Typography sx={{ fontSize: 11, color: t.primaryColor, fontWeight: 600 }}>
+              {recordHealthScore(bestRecord).toFixed(1)}点
+            </Typography>
+          </Box>
+          <Box sx={{ flex: 1, bgcolor: 'rgba(255,255,255,0.15)', borderRadius: 2, p: 1.5, border: `1px solid ${t.borderColor}` }}>
+            <Typography sx={{ fontSize: 10, color: t.subTextColor }}>最悪日 💧</Typography>
+            <Typography sx={{ fontSize: 12, fontWeight: 700, color: t.textColor, mt: 0.3 }}>
+              {formatMonthDay(worstRecord.timestamp)}
+            </Typography>
+            <Typography sx={{ fontSize: 11, color: t.primaryColor, fontWeight: 600 }}>
+              {recordHealthScore(worstRecord).toFixed(1)}点
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/frontend/src/components/SnsPage/WeeklySummaryCard.tsx
+++ b/packages/frontend/src/components/SnsPage/WeeklySummaryCard.tsx
@@ -25,10 +25,12 @@ export default function WeeklySummaryCard({ records, theme, size }: Props) {
   const twoWeeksAgo = new Date(now);
   twoWeeksAgo.setDate(now.getDate() - 14);
 
-  const weekRecords = records.filter((r) => {
-    const d = new Date(r.timestamp);
-    return d >= weekAgo && d <= now;
-  });
+  const weekRecords = records
+    .filter((r) => {
+      const d = new Date(r.timestamp);
+      return d >= weekAgo && d <= now;
+    })
+    .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
   const prevWeekRecords = records.filter((r) => {
     const d = new Date(r.timestamp);
     return d >= twoWeeksAgo && d < weekAgo;

--- a/packages/frontend/src/components/SnsPage/index.tsx
+++ b/packages/frontend/src/components/SnsPage/index.tsx
@@ -1,6 +1,7 @@
 // ============================================================
 // [Add] PBI-37: SNS出力用画面（Twitter 最適化レイアウト）
 // [Add] PBI-38: 生成AI向けプロンプト生成
+// [Add] PBI-54: テーマ・サイズプリセット統合
 // ============================================================
 
 import { useRef, useState } from 'react';
@@ -10,10 +11,13 @@ import {
   Button,
   Card,
   CardContent,
+  Chip,
   Grid,
   IconButton,
   InputAdornment,
   OutlinedInput,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
   Typography,
   useMediaQuery,
@@ -22,24 +26,32 @@ import {
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import SpaIcon from '@mui/icons-material/Spa';
+import NotificationsIcon from '@mui/icons-material/Notifications';
 import SkinRadarChart from '../Dashboard/SkinRadarChart';
 import TrendChart from '../Dashboard/TrendChart';
 import CalendarHeatmap from '../Dashboard/CalendarHeatmap';
 import LoadingBox from '../shared/LoadingBox';
 import PageHeader from '../shared/PageHeader';
 import ChartExportButton from '../shared/ChartExportButton';
-import { useSkinData } from '../../hooks/useSkinData';
+import { useSkinData, useCosmeticsMaster } from '../../hooks/useSkinData';
+import { useNotifications } from '../../hooks/useNotifications';
 import { NormalizedRecord, SkinMetrics } from '../../types';
 import { formatFullDate } from '../../utils/format';
-import { METRIC_COLORS, METRIC_LABELS, SCALE_MAX } from '../../constants';
+import { METRIC_COLORS, METRIC_LABELS, SCALE_MAX, CARD_THEMES, CARD_SIZES, CardTheme, CardSize } from '../../constants';
+import WeeklySummaryCard from './WeeklySummaryCard';
+import WeeklyScoreCard from './WeeklyScoreCard';
+import BeforeAfterCard from './BeforeAfterCard';
+import CompactCalendarHeatmap from './CompactCalendarHeatmap';
+import CosmeticsRankingCard from './CosmeticsRankingCard';
+import FactorsInsightCard from './FactorsInsightCard';
 
 // ============================================================
 // スコアに応じた色・ラベルを返すユーティリティ（スコア範囲 20-70 を想定）
 // ============================================================
 function scoreColor(v: number): string {
-  if (v >= 60) return '#388e3c'; // 落ち着いたグリーン
-  if (v >= 45) return '#e65100'; // 落ち着いたオレンジ
-  return '#c62828';               // 落ち着いたレッド
+  if (v >= 60) return '#388e3c';
+  if (v >= 45) return '#e65100';
+  return '#c62828';
 }
 function scoreBgColor(v: number): string {
   if (v >= 60) return '#e8f5e9';
@@ -55,7 +67,6 @@ function scoreLabel(avg: number): string {
 
 // ============================================================
 // [Add] PBI-38: 生成AI向けプロンプト生成
-// ChatGPT / Claude 等に貼り付けてSNS投稿文を作成させるためのプロンプト
 // ============================================================
 function generateAiPrompt(record: NormalizedRecord): string {
   const date = formatFullDate(record.timestamp);
@@ -101,6 +112,37 @@ function generateAiPrompt(record: NormalizedRecord): string {
     `　肌色: ${record.cheek.tone}　水分量: ${record.cheek.moisture}　油分量: ${record.cheek.oil}　弾性力: ${record.cheek.elasticity}`,
     ...(cosmeticSection.length > 0 ? ['', '使用コスメ', ...cosmeticSection] : []),
     ...(lifelogSection.length > 0 ? ['', 'ライフログ', ...lifelogSection] : []),
+  ].join('\n');
+}
+
+function generateWeeklyAiPrompt(records: NormalizedRecord[]): string {
+  if (records.length === 0) return '';
+  const now = new Date();
+  const weekAgo = new Date(now);
+  weekAgo.setDate(now.getDate() - 7);
+  const weekRecords = records.filter((r) => new Date(r.timestamp) >= weekAgo);
+  if (weekRecords.length === 0) return '';
+
+  const avgScore = Math.round(
+    weekRecords.reduce((s, r) =>
+      s + (r.forehead.tone + r.forehead.moisture + r.forehead.oil + r.forehead.elasticity +
+           r.cheek.tone + r.cheek.moisture + r.cheek.oil + r.cheek.elasticity) / 8,
+    0) / weekRecords.length
+  );
+
+  return [
+    'あなたはSNS投稿の文章作成アシスタントです。',
+    '以下の週間肌ケアデータをもとに、Twitter（X）への週次投稿文を作成してください。',
+    '',
+    '【要件】',
+    '・前向きで振り返りを促すトーン',
+    '・絵文字を適度に使用',
+    '・140文字以内（日本語）',
+    '・関連ハッシュタグを末尾に3〜5個追加',
+    '',
+    '【週間データ】',
+    `記録件数: ${weekRecords.length}件`,
+    `週間平均スコア: ${avgScore} / ${SCALE_MAX}（${scoreLabel(avgScore)}）`,
   ].join('\n');
 }
 
@@ -159,8 +201,6 @@ function ScoreSummaryCard({ record }: SummaryCardProps) {
   );
   const color   = scoreColor(avg);
   const bgColor = scoreBgColor(avg);
-
-  // 進捗バー用に 20-70 レンジを 0-100% に正規化
   const progressPct = Math.round(Math.min(100, Math.max(0, (avg - 20) / 50 * 100)));
 
   return (
@@ -199,7 +239,6 @@ function ScoreSummaryCard({ record }: SummaryCardProps) {
           boxShadow: '0 1px 6px rgba(0,0,0,0.07)',
         }}
       >
-        {/* スコアサークル（conic-gradient リング） */}
         <Box
           sx={{
             width: { xs: 64, sm: 72 },
@@ -312,23 +351,35 @@ function ScoreSummaryCard({ record }: SummaryCardProps) {
 // ============================================================
 export default function SnsPage() {
   const { records, loading, error } = useSkinData('all');
+  const { master } = useCosmeticsMaster();
   const latestRecord = records.length > 0 ? records[records.length - 1] : null;
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const muiTheme = useTheme();
+  const isMobile = useMediaQuery(muiTheme.breakpoints.down('sm'));
+
+  // [Add] PBI-37: 日次/週次切り替え
+  const [mode, setMode] = useState<'daily' | 'weekly'>('daily');
+  // [Add] PBI-54: テーマ・サイズプリセット
+  const [theme, setTheme] = useState<CardTheme>('pastel');
+  const [size, setSize] = useState<CardSize>('square');
 
   const [prompt, setPrompt] = useState<string>('');
   const [copied, setCopied] = useState(false);
 
   const summaryRef  = useRef<HTMLDivElement>(null);
-  // [Add] PBI-37: レーダーも正方形でエクスポート
   const radarRef    = useRef<HTMLDivElement>(null);
   const trendRef    = useRef<HTMLDivElement>(null);
   const calendarRef = useRef<HTMLDivElement>(null);
 
-  // [Add] PBI-38: 生成AIプロンプトを生成
+  // [Add] PBI-53: ブラウザ通知
+  const { requestPermission, permission } = useNotifications(records);
+
   const handleGeneratePrompt = () => {
-    if (!latestRecord) return;
-    setPrompt(generateAiPrompt(latestRecord));
+    if (mode === 'daily') {
+      if (!latestRecord) return;
+      setPrompt(generateAiPrompt(latestRecord));
+    } else {
+      setPrompt(generateWeeklyAiPrompt(records));
+    }
   };
 
   const handleCopyPrompt = async () => {
@@ -351,58 +402,250 @@ export default function SnsPage() {
 
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
+      {/* ── [Add] PBI-37 / PBI-54: コントロールバー ── */}
+      <Card elevation={0} sx={{ mb: 3 }}>
+        <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
+          <Box display="flex" flexWrap="wrap" gap={2} alignItems="flex-start">
+            <Box>
+              <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>モード</Typography>
+              <ToggleButtonGroup
+                size="small"
+                value={mode}
+                exclusive
+                onChange={(_, v) => v && setMode(v as 'daily' | 'weekly')}
+              >
+                <ToggleButton value="daily" sx={{ fontSize: 12, px: 2 }}>日次</ToggleButton>
+                <ToggleButton value="weekly" sx={{ fontSize: 12, px: 2 }}>週次</ToggleButton>
+              </ToggleButtonGroup>
+            </Box>
+
+            <Box>
+              <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>テーマ</Typography>
+              <Box display="flex" flexWrap="wrap" gap={0.75}>
+                {(Object.keys(CARD_THEMES) as CardTheme[]).map((t) => (
+                  <Chip
+                    key={t}
+                    label={CARD_THEMES[t].label}
+                    size="small"
+                    onClick={() => setTheme(t)}
+                    sx={{
+                      bgcolor: theme === t ? CARD_THEMES[t].chipColor : undefined,
+                      fontWeight: theme === t ? 700 : 400,
+                      border: theme === t ? '2px solid #9c27b0' : '1px solid #e0e0e0',
+                      cursor: 'pointer',
+                    }}
+                  />
+                ))}
+              </Box>
+            </Box>
+
+            <Box>
+              <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>サイズ</Typography>
+              <ToggleButtonGroup
+                size="small"
+                value={size}
+                exclusive
+                onChange={(_, v) => v && setSize(v as CardSize)}
+              >
+                {(Object.keys(CARD_SIZES) as CardSize[]).map((s) => (
+                  <ToggleButton key={s} value={s} sx={{ fontSize: 11, px: 1.5 }}>
+                    {CARD_SIZES[s].icon} {CARD_SIZES[s].label}
+                  </ToggleButton>
+                ))}
+              </ToggleButtonGroup>
+            </Box>
+
+            {permission === 'default' && (
+              <Box>
+                <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>通知</Typography>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<NotificationsIcon />}
+                  onClick={requestPermission}
+                >
+                  通知を許可
+                </Button>
+              </Box>
+            )}
+          </Box>
+        </CardContent>
+      </Card>
+
       {loading ? (
         <LoadingBox />
       ) : (
         <Grid container spacing={{ xs: 2, sm: 3 }}>
 
-          {/* ── スコアサマリー（正方形・SNS画像メイン） ── */}
-          {latestRecord && (
-            <Grid item xs={12} md={6}>
-              <Card elevation={0}>
-                <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                  <Box display="flex" justifyContent="space-between" alignItems="center" mb={1.5}>
-                    <Box>
-                      <Typography variant="subtitle1" fontWeight={600}>スコアサマリー</Typography>
-                      <Typography variant="caption" color="text.secondary">1:1 正方形（Twitter推奨）</Typography>
+          {mode === 'daily' ? (
+            <>
+              {/* ── 日次: スコアサマリー ── */}
+              {latestRecord && (
+                <Grid item xs={12} md={6}>
+                  <Card elevation={0}>
+                    <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
+                      <Box display="flex" justifyContent="space-between" alignItems="center" mb={1.5}>
+                        <Box>
+                          <Typography variant="subtitle1" fontWeight={600}>スコアサマリー</Typography>
+                          <Typography variant="caption" color="text.secondary">1:1 正方形（Twitter推奨）</Typography>
+                        </Box>
+                        <ChartExportButton targetRef={summaryRef} filename="sns-skin-summary" />
+                      </Box>
+                      <Box ref={summaryRef}>
+                        <ScoreSummaryCard record={latestRecord} />
+                      </Box>
+                    </CardContent>
+                  </Card>
+                </Grid>
+              )}
+
+              {/* ── 日次: レーダーチャート ── */}
+              <Grid item xs={12} md={6}>
+                <Card elevation={0}>
+                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
+                    <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+                      <Box>
+                        <Typography variant="subtitle1" fontWeight={600}>最新肌状態</Typography>
+                        <Typography variant="caption" color="text.secondary">1:1 正方形</Typography>
+                      </Box>
+                      <ChartExportButton targetRef={radarRef} filename="sns-skin-radar" />
                     </Box>
-                    <ChartExportButton targetRef={summaryRef} filename="sns-skin-summary" />
-                  </Box>
-                  <Box ref={summaryRef}>
-                    <ScoreSummaryCard record={latestRecord} />
-                  </Box>
-                </CardContent>
-              </Card>
-            </Grid>
+                    {/* [Add] PBI-37: 正方形コンテナ */}
+                    <Box
+                      ref={radarRef}
+                      sx={{
+                        aspectRatio: '1 / 1',
+                        bgcolor: '#fafafa',
+                        borderRadius: 2,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        justifyContent: 'center',
+                        p: { xs: 1, sm: 2 },
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <SkinRadarChart record={latestRecord} />
+                    </Box>
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              {/* ── 日次: 推移グラフ ── */}
+              <Grid item xs={12}>
+                <Card elevation={0}>
+                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
+                    <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+                      <Box>
+                        <Typography variant="subtitle1" fontWeight={600}>推移グラフ</Typography>
+                        <Typography variant="caption" color="text.secondary">横長（16:9 相当）</Typography>
+                      </Box>
+                      <ChartExportButton targetRef={trendRef} filename="sns-skin-trend" />
+                    </Box>
+                    <Box ref={trendRef} sx={{ bgcolor: 'background.paper', borderRadius: 2 }}>
+                      <TrendChart records={records} />
+                    </Box>
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              {/* ── 日次: 365日カレンダー ── */}
+              <Grid item xs={12}>
+                <Card elevation={0}>
+                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
+                    <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+                      <Box>
+                        <Typography variant="subtitle1" fontWeight={600}>365日カレンダー</Typography>
+                        <Typography variant="caption" color="text.secondary">横長</Typography>
+                      </Box>
+                      <ChartExportButton targetRef={calendarRef} filename="sns-skin-calendar" />
+                    </Box>
+                    <Box ref={calendarRef} sx={{ bgcolor: 'background.paper', borderRadius: 2 }}>
+                      <CalendarHeatmap records={records} />
+                    </Box>
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              {/* ── 日次: BeforeAfterCard ── */}
+              <Grid item xs={12} md={6}>
+                <Card elevation={0}>
+                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
+                    <Typography variant="subtitle1" fontWeight={600} mb={1.5}>Before / After 比較</Typography>
+                    <BeforeAfterCard records={records} theme={theme} size={size} />
+                  </CardContent>
+                </Card>
+              </Grid>
+            </>
+          ) : (
+            <>
+              {/* ── 週次: WeeklySummaryCard ── */}
+              <Grid item xs={12} md={6}>
+                <Card elevation={0}>
+                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
+                    <Typography variant="subtitle1" fontWeight={600} mb={1.5}>週間サマリー</Typography>
+                    <WeeklySummaryCard records={records} theme={theme} size={size} />
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              {/* ── 週次: TrendChart ── */}
+              <Grid item xs={12}>
+                <Card elevation={0}>
+                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
+                    <Typography variant="subtitle1" fontWeight={600} mb={1}>推移グラフ（週次）</Typography>
+                    <TrendChart records={records} />
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              {/* ── 週次: WeeklyScoreCard ── */}
+              <Grid item xs={12} md={6}>
+                <Card elevation={0}>
+                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
+                    <Typography variant="subtitle1" fontWeight={600} mb={1.5}>週間スコアカード</Typography>
+                    <WeeklyScoreCard records={records} theme={theme} size={size} />
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              {/* ── 週次: BeforeAfterCard ── */}
+              <Grid item xs={12} md={6}>
+                <Card elevation={0}>
+                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
+                    <Typography variant="subtitle1" fontWeight={600} mb={1.5}>Before / After 比較</Typography>
+                    <BeforeAfterCard records={records} theme={theme} size={size} />
+                  </CardContent>
+                </Card>
+              </Grid>
+            </>
           )}
 
-          {/* ── レーダーチャート（正方形） ── */}
+          {/* ── 両モード共通: CompactCalendarHeatmap ── */}
           <Grid item xs={12} md={6}>
             <Card elevation={0}>
               <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
-                  <Box>
-                    <Typography variant="subtitle1" fontWeight={600}>最新肌状態</Typography>
-                    <Typography variant="caption" color="text.secondary">1:1 正方形</Typography>
-                  </Box>
-                  <ChartExportButton targetRef={radarRef} filename="sns-skin-radar" />
-                </Box>
-                {/* [Add] PBI-37: 正方形コンテナ */}
-                <Box
-                  ref={radarRef}
-                  sx={{
-                    aspectRatio: '1 / 1',
-                    bgcolor: '#fafafa',
-                    borderRadius: 2,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'center',
-                    p: { xs: 1, sm: 2 },
-                    overflow: 'hidden',
-                  }}
-                >
-                  <SkinRadarChart record={latestRecord} />
-                </Box>
+                <Typography variant="subtitle1" fontWeight={600} mb={1.5}>直近3ヶ月カレンダー</Typography>
+                <CompactCalendarHeatmap records={records} theme={theme} size={size} />
+              </CardContent>
+            </Card>
+          </Grid>
+
+          {/* ── 両モード共通: CosmeticsRankingCard ── */}
+          <Grid item xs={12} md={6}>
+            <Card elevation={0}>
+              <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
+                <Typography variant="subtitle1" fontWeight={600} mb={1.5}>コスメランキング</Typography>
+                <CosmeticsRankingCard records={records} master={master} theme={theme} size={size} />
+              </CardContent>
+            </Card>
+          </Grid>
+
+          {/* ── 両モード共通: FactorsInsightCard ── */}
+          <Grid item xs={12} md={6}>
+            <Card elevation={0}>
+              <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
+                <Typography variant="subtitle1" fontWeight={600} mb={1.5}>生活習慣インサイト</Typography>
+                <FactorsInsightCard records={records} theme={theme} size={size} />
               </CardContent>
             </Card>
           </Grid>
@@ -429,7 +672,7 @@ export default function SnsPage() {
                     size="small"
                     startIcon={<AutoAwesomeIcon />}
                     onClick={handleGeneratePrompt}
-                    disabled={!latestRecord}
+                    disabled={mode === 'daily' ? !latestRecord : records.length === 0}
                     variant="outlined"
                     fullWidth={isMobile}
                   >
@@ -456,47 +699,11 @@ export default function SnsPage() {
                   }
                   sx={{ fontSize: 13 }}
                 />
-                {!latestRecord && (
+                {mode === 'daily' && !latestRecord && (
                   <Typography variant="caption" color="text.secondary" mt={0.5} display="block">
                     ※ 肌データを記録するとプロンプトを生成できます
                   </Typography>
                 )}
-              </CardContent>
-            </Card>
-          </Grid>
-
-          {/* ── 推移グラフ（横長） ── */}
-          <Grid item xs={12}>
-            <Card elevation={0}>
-              <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
-                  <Box>
-                    <Typography variant="subtitle1" fontWeight={600}>推移グラフ</Typography>
-                    <Typography variant="caption" color="text.secondary">横長（16:9 相当）</Typography>
-                  </Box>
-                  <ChartExportButton targetRef={trendRef} filename="sns-skin-trend" />
-                </Box>
-                <Box ref={trendRef} sx={{ bgcolor: 'background.paper', borderRadius: 2 }}>
-                  <TrendChart records={records} />
-                </Box>
-              </CardContent>
-            </Card>
-          </Grid>
-
-          {/* ── 365日カレンダー（横長） ── */}
-          <Grid item xs={12}>
-            <Card elevation={0}>
-              <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
-                  <Box>
-                    <Typography variant="subtitle1" fontWeight={600}>365日カレンダー</Typography>
-                    <Typography variant="caption" color="text.secondary">横長</Typography>
-                  </Box>
-                  <ChartExportButton targetRef={calendarRef} filename="sns-skin-calendar" />
-                </Box>
-                <Box ref={calendarRef} sx={{ bgcolor: 'background.paper', borderRadius: 2 }}>
-                  <CalendarHeatmap records={records} />
-                </Box>
               </CardContent>
             </Card>
           </Grid>

--- a/packages/frontend/src/constants.ts
+++ b/packages/frontend/src/constants.ts
@@ -57,3 +57,66 @@ export function getScoreColor(value: number): 'success' | 'warning' | 'error' {
   if (value >= 40) return 'warning';
   return 'error';
 }
+
+// カードテーマ
+export type CardTheme = 'minimal' | 'pop' | 'luxury' | 'pastel';
+export const CARD_THEMES: Record<CardTheme, {
+  label: string;
+  chipColor: string;
+  background: string;
+  primaryColor: string;
+  textColor: string;
+  subTextColor: string;
+  borderColor: string;
+  fontWeight: number;
+}> = {
+  minimal: {
+    label: 'ミニマル', chipColor: '#F5F5F5', background: '#FFFFFF',
+    primaryColor: '#424242', textColor: '#212121', subTextColor: '#757575',
+    borderColor: '#E0E0E0', fontWeight: 400,
+  },
+  pop: {
+    label: 'ポップ', chipColor: '#FF6B9D', background: 'linear-gradient(135deg, #FF6B9D 0%, #FFB347 100%)',
+    primaryColor: '#FFFFFF', textColor: '#FFFFFF', subTextColor: 'rgba(255,255,255,0.85)',
+    borderColor: 'rgba(255,255,255,0.4)', fontWeight: 700,
+  },
+  luxury: {
+    label: 'ラグジュアリー', chipColor: '#1A1A2E', background: 'linear-gradient(135deg, #1A1A2E 0%, #16213E 50%, #0F3460 100%)',
+    primaryColor: '#FFD700', textColor: '#F5F5F5', subTextColor: '#B0B0B0',
+    borderColor: '#FFD700', fontWeight: 500,
+  },
+  pastel: {
+    label: 'パステル', chipColor: '#FFB3C6', background: 'linear-gradient(135deg, #FFB3C6 0%, #C9B8FF 50%, #B8E4FF 100%)',
+    primaryColor: '#6B4C93', textColor: '#4A3060', subTextColor: '#7B6B8D',
+    borderColor: 'rgba(107,76,147,0.3)', fontWeight: 500,
+  },
+};
+
+// カードサイズ
+export type CardSize = 'square' | 'story' | 'wide';
+export const CARD_SIZES: Record<CardSize, {
+  label: string; icon: string; width: number; height: number; description: string;
+}> = {
+  square: { label: '正方形', icon: '⬛', width: 600, height: 600,  description: 'Instagram / X' },
+  story:  { label: '縦長',   icon: '📱', width: 450, height: 800,  description: 'Story / TikTok' },
+  wide:   { label: '横長',   icon: '🖥',  width: 800, height: 450,  description: 'X ヘッダー' },
+};
+
+// スコアランク
+export const RANK_CONFIG = {
+  S: { min: 90, color: '#FFD700', label: 'PERFECT' },
+  A: { min: 75, color: '#C0C0C0', label: 'GREAT' },
+  B: { min: 60, color: '#CD7F32', label: 'GOOD' },
+  C: { min: 45, color: '#78909C', label: 'FAIR' },
+  D: { min: 0,  color: '#546E7A', label: 'KEEP UP' },
+} as const;
+
+export type ScoreRank = keyof typeof RANK_CONFIG;
+
+export const getScoreRank = (score: number): ScoreRank => {
+  if (score >= 90) return 'S';
+  if (score >= 75) return 'A';
+  if (score >= 60) return 'B';
+  if (score >= 45) return 'C';
+  return 'D';
+};

--- a/packages/frontend/src/hooks/useNotifications.ts
+++ b/packages/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,62 @@
+import { useEffect } from 'react';
+import { NormalizedRecord } from '../types';
+import { recordHealthScore } from '../utils/metrics';
+
+export function useNotifications(records: NormalizedRecord[]) {
+  useEffect(() => {
+    if (!('Notification' in window)) return;
+    if (Notification.permission !== 'granted') return;
+
+    const lastNotified = localStorage.getItem('lastNotifiedDate');
+    const today = new Date().toDateString();
+    if (lastNotified === today) return;
+
+    if (records.length < 2) return;
+
+    const latest = records[records.length - 1];
+    const latestScore = recordHealthScore(latest);
+
+    // トリガー1: 過去最高更新
+    const historicalMax = Math.max(...records.slice(0, -1).map((r) => recordHealthScore(r)));
+    if (latestScore > historicalMax) {
+      new Notification('🏆 過去最高の肌スコアを記録！', {
+        body: `今日のスコア: ${latestScore.toFixed(1)}点 — SNSで投稿してみましょう！`,
+        tag: 'peak',
+      });
+      localStorage.setItem('lastNotifiedDate', today);
+      return;
+    }
+
+    // トリガー2: 前日比±10点
+    const prevScore = recordHealthScore(records[records.length - 2]);
+    const diff = latestScore - prevScore;
+    if (Math.abs(diff) >= 10) {
+      new Notification(diff > 0 ? '📈 肌コンディションが大幅改善！' : '📉 肌コンディションが低下', {
+        body: `前回比 ${diff > 0 ? '+' : ''}${diff.toFixed(1)}点 — 変化をSNSで共有しましょう`,
+        tag: 'bigChange',
+      });
+      localStorage.setItem('lastNotifiedDate', today);
+      return;
+    }
+
+    // トリガー3: 日曜日週次レポート
+    if (new Date().getDay() === 0) {
+      new Notification('📊 今週の肌レポートを投稿しよう', {
+        body: 'SNS出力画面から週次レポートを確認・共有できます',
+        tag: 'weeklyReport',
+      });
+      localStorage.setItem('lastNotifiedDate', today);
+    }
+  }, [records]);
+
+  const requestPermission = async () => {
+    if (!('Notification' in window)) return false;
+    const result = await Notification.requestPermission();
+    return result === 'granted';
+  };
+
+  return {
+    requestPermission,
+    permission: typeof Notification !== 'undefined' ? Notification.permission : ('default' as NotificationPermission),
+  };
+}

--- a/packages/frontend/src/hooks/useNotifications.ts
+++ b/packages/frontend/src/hooks/useNotifications.ts
@@ -4,6 +4,7 @@ import { recordHealthScore } from '../utils/metrics';
 
 export function useNotifications(records: NormalizedRecord[]) {
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     if (!('Notification' in window)) return;
     if (Notification.permission !== 'granted') return;
 
@@ -28,7 +29,10 @@ export function useNotifications(records: NormalizedRecord[]) {
     }
 
     // トリガー2: 前日比±10点
-    const prevScore = recordHealthScore(records[records.length - 2]);
+    const latestDate = latest.timestamp.slice(0, 10);
+    const prevRecord = [...records].slice(0, -1).reverse().find(r => r.timestamp.slice(0, 10) < latestDate);
+    if (!prevRecord) return;
+    const prevScore = recordHealthScore(prevRecord);
     const diff = latestScore - prevScore;
     if (Math.abs(diff) >= 10) {
       new Notification(diff > 0 ? '📈 肌コンディションが大幅改善！' : '📉 肌コンディションが低下', {

--- a/packages/frontend/src/utils/metrics.ts
+++ b/packages/frontend/src/utils/metrics.ts
@@ -39,7 +39,7 @@ function normalizeScore(value: number, min: number, max: number): number {
  *   oil:         30-50（低めは乾燥、高めは過剰）
  *   elasticity:  30-70（高いほど良い）
  */
-function recordHealthScore(r: NormalizedRecord): number {
+export function recordHealthScore(r: NormalizedRecord): number {
   const score = (v: number, min: number, max: number) => normalizeScore(v, min, max);
   return (
     score(r.forehead.tone,        20, 70) + score(r.forehead.moisture, 30, 50) +


### PR DESCRIPTION
## Why

Milestone 6「SNSとの連携強化」として、SNS出力画面を大幅拡充する。日次/週次の切り替え、4テーマ×3サイズのカードプリセット、6種の新規SNSカード、ブラウザプッシュ通知を追加する。

resolves #37
resolves #48
resolves #49
resolves #50
resolves #51
resolves #52
resolves #53
resolves #54

## What

- **#37** SnsPage に日次/週次トグル・テーマ（4種）・サイズ（3種）のコントロールバーを追加
- **#48** `BeforeAfterCard`: 期間選択付き BEFORE/AFTER 比較 + キャッチコピー自動生成
- **#49** `WeeklyScoreCard`: S〜D ランク大型表示 + 8指標 LinearProgress（適正レンジ正規化済み）
- **#50** `CompactCalendarHeatmap`: 直近3ヶ月・18pxセル・表示範囲内の最良日👑/最悪日💧アイコン
- **#51** `CosmeticsRankingCard`: 貢献スコア算出（使用日 vs 未使用日平均差）+ 表彰台スタイルTOP3
- **#52** `FactorsInsightCard`: 睡眠/飲酒/出張条件別スコア差を自動インサイト表示
- **#53** `useNotifications`: 過去最高更新 / ±10点変化 / 日曜週次レポートの3トリガー通知
- **#54** テーマ/サイズセレクター統合、全カードへのテーマ適用

## How

**定数追加（`constants.ts`）:**
- `CardTheme` / `CARD_THEMES`: minimal/pop/luxury/pastel の4テーマ定義
- `CardSize` / `CARD_SIZES`: square/story/wide の3サイズ（px寸法付き）
- `RANK_CONFIG` / `getScoreRank()`: S/A/B/C/D ランク算出

**`utils/metrics.ts`:** `recordHealthScore()` を `export` 化

**新規コンポーネント（`SnsPage/` 配下）:**
- `WeeklySummaryCard.tsx`: 直近7日間フィルタ・ソート確定・前週比計算
- `WeeklyScoreCard.tsx`: `getScoreRank()` によるランク・指標ごとの METRIC_RANGE 正規化
- `BeforeAfterCard.tsx`: 期間不足時に「全期間で比較」注記を表示
- `CompactCalendarHeatmap.tsx`: 表示90日内でベスト/ワーストを算出（長期ユーザー対応）
- `CosmeticsRankingCard.tsx`: 5件未満除外・2種類時は専用メッセージ
- `FactorsInsightCard.tsx`: |delta|上位3インサイト自動抽出

**`hooks/useNotifications.ts`（新規）:**
- SSRガード（`typeof window === 'undefined'`）
- 前日比を「異なる日付の直前レコード」で比較（同日複数記録対応）
- `localStorage` で1日1回制限

## Test

- [ ] SnsPage のコントロールバーで日次/週次切り替えが機能することを確認
- [ ] テーマ変更（minimal/pop/luxury/pastel）でカードの色・背景が変わることを確認
- [ ] BeforeAfterCard で1週間を選択し、データ不足時に「全期間で比較」注記が出ることを確認
- [ ] WeeklyScoreCard でランクとLinearProgressが表示されることを確認
- [ ] CompactCalendarHeatmap で直近3ヶ月の表示、👑と💧が見える日付内に存在することを確認
- [ ] CosmeticsRankingCard でカテゴリ切り替えと表彰台表示を確認
- [ ] 通知許可ボタンをクリックして権限ダイアログが表示されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01MDw6ttZniXXg5wJdqfUvtD)_