### PR TITLE
[feat] add: Milestone 7 — SNS出力 週次/月次リニューアル・分析タブ分離

### DIFF
--- a/packages/frontend/src/components/Dashboard/CosmeticsRadarChart.tsx
+++ b/packages/frontend/src/components/Dashboard/CosmeticsRadarChart.tsx
@@ -1,0 +1,113 @@
+// ============================================================
+// コスメ比較レーダーチャート
+// カテゴリ別に使用頻度上位3製品の平均肌指標（水分・油分・弾性）を比較する
+// ============================================================
+
+import { useState } from 'react';
+import { Box } from '@mui/material';
+import {
+  Radar,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Legend,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { NormalizedRecord } from '../../types';
+import { COSMETIC_FIELD_LABELS } from '../../constants';
+import { avgMetrics } from '../../utils/metrics';
+import FilterToggleGroup from '../shared/FilterToggleGroup';
+import EmptyStateBox from '../shared/EmptyStateBox';
+
+type Category = 'toner' | 'essence' | 'lotion' | 'primer';
+
+interface Props {
+  records: NormalizedRecord[];
+}
+
+const COLORS = ['#e91e63', '#2196f3', '#4caf50', '#ff9800'];
+
+const METRIC_KEYS = ['moisture', 'oil', 'elasticity'] as const;
+const METRIC_LABEL_MAP: Record<typeof METRIC_KEYS[number], string> = {
+  moisture: '水分',
+  oil: '油分',
+  elasticity: '弾性',
+};
+
+export default function CosmeticsRadarChart({ records }: Props) {
+  const [category, setCategory] = useState<Category>('toner');
+
+  // 使用頻度上位3製品を取得
+  const usageCounts = new Map<string, number>();
+  for (const r of records) {
+    const name = r.cosmetics[category];
+    if (name) usageCounts.set(name, (usageCounts.get(name) ?? 0) + 1);
+  }
+
+  const topCosmetics = Array.from(usageCounts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([name]) => name);
+
+  if (topCosmetics.length < 2) {
+    return (
+      <Box>
+        <Box display="flex" justifyContent="center" mb={1}>
+          <FilterToggleGroup
+            label="カテゴリ"
+            options={COSMETIC_FIELD_LABELS}
+            value={category}
+            onChange={setCategory}
+          />
+        </Box>
+        <EmptyStateBox message="比較に必要なデータが不足しています（2種類以上の化粧品記録が必要）" />
+      </Box>
+    );
+  }
+
+  // レーダーデータ構築: axes = 指標, polygons = 製品
+  const data = METRIC_KEYS.map((key) => {
+    const point: Record<string, string | number> = { metric: METRIC_LABEL_MAP[key] };
+    topCosmetics.forEach((name) => {
+      const cosRecords = records.filter((r) => r.cosmetics[category] === name);
+      const fhAvg = avgMetrics(cosRecords, 'forehead');
+      const chAvg = avgMetrics(cosRecords, 'cheek');
+      point[name] = Math.round((fhAvg[key] + chAvg[key]) / 2);
+    });
+    return point;
+  });
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="center" mb={1}>
+        <FilterToggleGroup
+          label="カテゴリ"
+          options={COSMETIC_FIELD_LABELS}
+          value={category}
+          onChange={setCategory}
+        />
+      </Box>
+      <ResponsiveContainer width="100%" height={280}>
+        <RadarChart data={data}>
+          <PolarGrid />
+          <PolarAngleAxis dataKey="metric" tick={{ fontSize: 12 }} />
+          <PolarRadiusAxis angle={30} domain={[0, 60]} tick={{ fontSize: 10 }} />
+          {topCosmetics.map((name, i) => (
+            <Radar
+              key={name}
+              name={name.length > 14 ? name.slice(0, 14) + '…' : name}
+              dataKey={name}
+              stroke={COLORS[i % COLORS.length]}
+              fill={COLORS[i % COLORS.length]}
+              fillOpacity={0.2}
+            />
+          ))}
+          <Legend wrapperStyle={{ fontSize: 11 }} />
+          <Tooltip contentStyle={{ fontSize: 12 }} />
+        </RadarChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}

--- a/packages/frontend/src/components/Dashboard/FactorsRadarChart.tsx
+++ b/packages/frontend/src/components/Dashboard/FactorsRadarChart.tsx
@@ -1,0 +1,90 @@
+// ============================================================
+// 生活習慣比較レーダーチャート
+// 睡眠・飲酒などのライフスタイル条件別に平均肌指標を比較する
+// ============================================================
+
+import { Box } from '@mui/material';
+import {
+  Radar,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Legend,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { NormalizedRecord } from '../../types';
+import { avgMetrics } from '../../utils/metrics';
+import EmptyStateBox from '../shared/EmptyStateBox';
+
+interface Props {
+  records: NormalizedRecord[];
+}
+
+const COLORS = ['#4caf50', '#f44336', '#2196f3', '#ff9800'];
+
+const METRIC_KEYS = ['moisture', 'oil', 'elasticity'] as const;
+const METRIC_LABEL_MAP: Record<typeof METRIC_KEYS[number], string> = {
+  moisture: '水分',
+  oil: '油分',
+  elasticity: '弾性',
+};
+
+export default function FactorsRadarChart({ records }: Props) {
+  if (records.length < 5) {
+    return <EmptyStateBox message="データ不足（5件以上の記録が必要）" />;
+  }
+
+  // ライフスタイル条件ごとにレコードをグループ化
+  const groups = [
+    { name: '睡眠7h+', recs: records.filter((r) => r.factors.sleepHours >= 7) },
+    {
+      name: '睡眠不足',
+      recs: records.filter((r) => r.factors.sleepHours > 0 && r.factors.sleepHours < 7),
+    },
+    { name: '飲酒なし', recs: records.filter((r) => !r.factors.alcohol) },
+    { name: '飲酒あり', recs: records.filter((r) => r.factors.alcohol) },
+  ].filter((g) => g.recs.length >= 3);
+
+  if (groups.length < 2) {
+    return (
+      <EmptyStateBox message="比較に必要なデータが不足しています（各条件3件以上必要）" />
+    );
+  }
+
+  // レーダーデータ構築: axes = 指標, polygons = 条件グループ
+  const data = METRIC_KEYS.map((key) => {
+    const point: Record<string, string | number> = { metric: METRIC_LABEL_MAP[key] };
+    groups.forEach((g) => {
+      const fhAvg = avgMetrics(g.recs, 'forehead');
+      const chAvg = avgMetrics(g.recs, 'cheek');
+      point[g.name] = Math.round((fhAvg[key] + chAvg[key]) / 2);
+    });
+    return point;
+  });
+
+  return (
+    <Box>
+      <ResponsiveContainer width="100%" height={280}>
+        <RadarChart data={data}>
+          <PolarGrid />
+          <PolarAngleAxis dataKey="metric" tick={{ fontSize: 12 }} />
+          <PolarRadiusAxis angle={30} domain={[0, 60]} tick={{ fontSize: 10 }} />
+          {groups.map((g, i) => (
+            <Radar
+              key={g.name}
+              name={g.name}
+              dataKey={g.name}
+              stroke={COLORS[i % COLORS.length]}
+              fill={COLORS[i % COLORS.length]}
+              fillOpacity={0.2}
+            />
+          ))}
+          <Legend wrapperStyle={{ fontSize: 11 }} />
+          <Tooltip contentStyle={{ fontSize: 12 }} />
+        </RadarChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}

--- a/packages/frontend/src/components/SnsPage/CombinedBeforeAfterCard.tsx
+++ b/packages/frontend/src/components/SnsPage/CombinedBeforeAfterCard.tsx
@@ -1,0 +1,130 @@
+import { useRef } from 'react';
+import { Box, Typography } from '@mui/material';
+import SpaIcon from '@mui/icons-material/Spa';
+import { NormalizedRecord } from '../../types';
+import { CardTheme, CardSize, CARD_THEMES } from '../../constants';
+import { recordHealthScore } from '../../utils/metrics';
+import { getPrevWeekRange, getPrevMonthRange, getPastDaysRange, filterByDateRange } from '../../utils/dateRange';
+import ChartExportButton from '../shared/ChartExportButton';
+
+interface CombinedBeforeAfterCardProps {
+  records: NormalizedRecord[];   // 全レコード（フィルタなし）
+  theme: CardTheme;
+  size: CardSize;
+}
+
+type PeriodSection = {
+  label: string;
+  beforeScore: number | null;
+  afterScore: number | null;
+  delta: number | null;
+  catchcopy: string | null;
+};
+
+export default function CombinedBeforeAfterCard({
+  records,
+  theme,
+  size: _size,
+}: CombinedBeforeAfterCardProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const t = CARD_THEMES[theme];
+
+  const periods = [
+    { ...getPrevWeekRange(), key: 'week' },
+    { ...getPrevMonthRange(), key: 'month' },
+    { ...getPastDaysRange(90), key: '3months' },
+  ];
+
+  const sections: PeriodSection[] = periods.map((period) => {
+    const periodRecords = filterByDateRange(records, period.start, period.end);
+
+    if (periodRecords.length < 2) {
+      return {
+        label: period.label,
+        beforeScore: null,
+        afterScore: null,
+        delta: null,
+        catchcopy: null,
+      };
+    }
+
+    const first = periodRecords[0];
+    const last = periodRecords[periodRecords.length - 1];
+    const beforeScore = recordHealthScore(first);
+    const afterScore = recordHealthScore(last);
+    const delta = afterScore - beforeScore;
+    const pct = beforeScore > 0 ? Math.round((delta / beforeScore) * 100) : 0;
+    const diffDays = Math.round(
+      (new Date(last.timestamp).getTime() - new Date(first.timestamp).getTime()) /
+        (1000 * 60 * 60 * 24)
+    );
+    const catchcopy =
+      delta > 0
+        ? `${diffDays}日間で${Math.abs(pct)}%改善！`
+        : delta < 0
+        ? `${diffDays}日間で${Math.abs(pct)}%低下`
+        : `${diffDays}日間スコアを維持中！`;
+
+    return { label: period.label, beforeScore, afterScore, delta, catchcopy };
+  });
+
+  return (
+    <>
+      <Box ref={cardRef} sx={{ background: t.background, borderRadius: 3, overflow: 'hidden', border: `1px solid ${t.borderColor}` }}>
+        {/* ヘッダー */}
+        <Box sx={{ p: 2, borderBottom: `1px solid ${t.borderColor}` }}>
+          <Box display="flex" alignItems="center" gap={0.5}>
+            <SpaIcon sx={{ color: t.primaryColor, fontSize: 14 }} />
+            <Typography sx={{ fontSize: 12, fontWeight: 700, color: t.primaryColor }}>
+              SkinJournal 肌変化レポート
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* 3セクション */}
+        {sections.map((sec, i) => (
+          <Box key={i} sx={{ p: 2, borderTop: i > 0 ? `1px solid ${t.borderColor}` : undefined }}>
+            <Typography sx={{ fontSize: 11, color: t.subTextColor, mb: 0.5 }}>{sec.label}</Typography>
+            {sec.beforeScore === null ? (
+              <Typography sx={{ fontSize: 11, color: t.subTextColor }}>
+                ※ 対象期間のデータが不足しています
+              </Typography>
+            ) : (
+              <Box display="flex" alignItems="center" gap={1}>
+                <Box textAlign="center">
+                  <Typography sx={{ fontSize: 11, color: t.subTextColor }}>BEFORE</Typography>
+                  <Typography sx={{ fontSize: 24, fontWeight: 300, color: t.textColor, opacity: 0.6 }}>
+                    {Math.round(sec.beforeScore)}
+                  </Typography>
+                </Box>
+                <Typography sx={{ fontSize: 20, color: t.subTextColor }}>→</Typography>
+                <Box textAlign="center">
+                  <Typography sx={{ fontSize: 11, color: t.primaryColor, fontWeight: 700 }}>AFTER</Typography>
+                  <Typography sx={{ fontSize: 24, fontWeight: 700, color: t.primaryColor }}>
+                    {Math.round(sec.afterScore!)}
+                  </Typography>
+                </Box>
+                <Box flex={1} />
+                <Typography sx={{
+                  fontSize: 16,
+                  fontWeight: 700,
+                  color: (sec.delta ?? 0) >= 0 ? '#388e3c' : '#c62828',
+                }}>
+                  {(sec.delta ?? 0) >= 0 ? '+' : ''}{Math.round(sec.delta ?? 0)}
+                </Typography>
+              </Box>
+            )}
+            {sec.catchcopy && sec.beforeScore !== null && (
+              <Typography sx={{ fontSize: 10, color: t.subTextColor, mt: 0.5 }}>
+                {sec.catchcopy}
+              </Typography>
+            )}
+          </Box>
+        ))}
+      </Box>
+      <Box display="flex" justifyContent="flex-end" mt={1}>
+        <ChartExportButton targetRef={cardRef} filename="sns-before-after-combined" />
+      </Box>
+    </>
+  );
+}

--- a/packages/frontend/src/components/SnsPage/PeriodSummaryCard.tsx
+++ b/packages/frontend/src/components/SnsPage/PeriodSummaryCard.tsx
@@ -1,0 +1,173 @@
+import { useRef } from 'react';
+import { Box, Typography } from '@mui/material';
+import SpaIcon from '@mui/icons-material/Spa';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
+import TrendingFlatIcon from '@mui/icons-material/TrendingFlat';
+import { NormalizedRecord } from '../../types';
+import { CardTheme, CardSize, CARD_THEMES, RANK_CONFIG, getScoreRank } from '../../constants';
+import { recordHealthScore } from '../../utils/metrics';
+import { formatMonthDay } from '../../utils/format';
+import ChartExportButton from '../shared/ChartExportButton';
+
+interface PeriodSummaryCardProps {
+  records: NormalizedRecord[];      // 当期間のフィルタ済みレコード（ソート済み）
+  prevRecords: NormalizedRecord[];  // 前期間のレコード（比較用）
+  label: string;                    // 期間ラベル（例: "7/6(月) 〜 7/12(日)"）
+  mode: 'weekly' | 'monthly';
+  theme: CardTheme;
+  size: CardSize;
+}
+
+export default function PeriodSummaryCard({
+  records,
+  prevRecords,
+  label,
+  mode: _mode,
+  theme,
+  size,
+}: PeriodSummaryCardProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const t = CARD_THEMES[theme];
+
+  if (records.length === 0) {
+    return (
+      <Box sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+        <Typography variant="body2">対象期間のデータがありません</Typography>
+      </Box>
+    );
+  }
+
+  // 期間平均スコア
+  const scores = records.map(r => recordHealthScore(r));
+  const avgScore = scores.reduce((s, v) => s + v, 0) / scores.length;
+  const rank = getScoreRank(avgScore);
+  const rankConfig = RANK_CONFIG[rank];
+
+  // 前期比
+  const prevAvg = prevRecords.length > 0
+    ? prevRecords.map(r => recordHealthScore(r)).reduce((s, v) => s + v, 0) / prevRecords.length
+    : null;
+  const diff = prevAvg !== null ? avgScore - prevAvg : null;
+
+  // 最良日 / 最悪日
+  const bestRecord = records.reduce((best, r) =>
+    recordHealthScore(r) > recordHealthScore(best) ? r : best
+  );
+  const worstRecord = records.reduce((worst, r) =>
+    recordHealthScore(r) < recordHealthScore(worst) ? r : worst
+  );
+
+  // 指標別平均（水分・油分・弾性）
+  const metricKeys = [
+    { key: 'moisture' as const, label: '水分' },
+    { key: 'oil' as const, label: '油分' },
+    { key: 'elasticity' as const, label: '弾性' },
+  ];
+  const metricAvgs = metricKeys.map(({ key, label: mLabel }) => ({
+    label: mLabel,
+    value: Math.round(
+      records.reduce((s, r) => s + (r.forehead[key] + r.cheek[key]) / 2, 0) / records.length
+    ),
+  }));
+
+  const aspectRatio = size === 'story' ? '9 / 16' : size === 'wide' ? '16 / 9' : '1 / 1';
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="flex-end" mb={0.5}>
+        <ChartExportButton targetRef={cardRef} filename="period-summary" />
+      </Box>
+      <Box
+        ref={cardRef}
+        sx={{
+          background: t.background,
+          borderRadius: 3,
+          p: 3,
+          aspectRatio,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          border: `1px solid ${t.borderColor}`,
+          overflow: 'hidden',
+        }}
+      >
+        {/* ヘッダー */}
+        <Box>
+          <Box display="flex" alignItems="center" gap={0.5} mb={0.5}>
+            <SpaIcon sx={{ color: t.primaryColor, fontSize: 14 }} />
+            <Typography sx={{ fontSize: 12, fontWeight: 700, color: t.primaryColor }}>
+              SkinJournal
+            </Typography>
+          </Box>
+          <Typography sx={{ fontSize: 11, color: t.subTextColor }}>{label}</Typography>
+        </Box>
+
+        {/* 期間平均スコア & ランク */}
+        <Box textAlign="center">
+          <Typography sx={{ fontSize: 11, color: t.subTextColor, mb: 0.5 }}>期間平均スコア</Typography>
+          <Typography sx={{ fontSize: '4rem', fontWeight: 900, color: rankConfig.color, lineHeight: 1.1 }}>
+            {rank}
+          </Typography>
+          <Typography sx={{ fontSize: '1.8rem', fontWeight: 700, color: t.primaryColor, lineHeight: 1.1 }}>
+            {avgScore.toFixed(1)}
+          </Typography>
+          <Typography sx={{ fontSize: 11, color: rankConfig.color, fontWeight: 600, mt: 0.3 }}>
+            {rankConfig.label}
+          </Typography>
+
+          {/* 指標別平均 */}
+          <Box display="flex" justifyContent="center" gap={1.5} mt={1}>
+            {metricAvgs.map(({ label: mLabel, value }) => (
+              <Typography key={mLabel} sx={{ fontSize: 10, color: t.subTextColor }}>
+                {mLabel} {value}
+              </Typography>
+            ))}
+          </Box>
+        </Box>
+
+        {/* 最良日 / 最悪日 */}
+        <Box display="flex" gap={1.5} justifyContent="space-between">
+          <Box sx={{ flex: 1, bgcolor: 'rgba(255,255,255,0.15)', borderRadius: 2, p: 1, border: `1px solid ${t.borderColor}` }}>
+            <Typography sx={{ fontSize: 10, color: t.subTextColor }}>最良日</Typography>
+            <Typography sx={{ fontSize: 11, fontWeight: 700, color: t.textColor, mt: 0.2 }}>
+              {formatMonthDay(bestRecord.timestamp)}
+            </Typography>
+            <Typography sx={{ fontSize: 10, color: t.primaryColor, fontWeight: 600 }}>
+              {recordHealthScore(bestRecord).toFixed(1)}点
+            </Typography>
+          </Box>
+          <Box sx={{ flex: 1, bgcolor: 'rgba(255,255,255,0.15)', borderRadius: 2, p: 1, border: `1px solid ${t.borderColor}` }}>
+            <Typography sx={{ fontSize: 10, color: t.subTextColor }}>最悪日</Typography>
+            <Typography sx={{ fontSize: 11, fontWeight: 700, color: t.textColor, mt: 0.2 }}>
+              {formatMonthDay(worstRecord.timestamp)}
+            </Typography>
+            <Typography sx={{ fontSize: 10, color: t.primaryColor, fontWeight: 600 }}>
+              {recordHealthScore(worstRecord).toFixed(1)}点
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* 前期比 */}
+        {diff !== null && (
+          <Box display="flex" alignItems="center" justifyContent="center" gap={0.5}>
+            {diff > 2 ? (
+              <TrendingUpIcon sx={{ color: '#4caf50', fontSize: 16 }} />
+            ) : diff < -2 ? (
+              <TrendingDownIcon sx={{ color: '#f44336', fontSize: 16 }} />
+            ) : (
+              <TrendingFlatIcon sx={{ color: t.subTextColor, fontSize: 16 }} />
+            )}
+            <Typography sx={{
+              fontSize: 12,
+              fontWeight: 700,
+              color: diff > 2 ? '#4caf50' : diff < -2 ? '#f44336' : t.subTextColor,
+            }}>
+              前期比 {diff > 0 ? '+' : ''}{diff.toFixed(1)}点
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/packages/frontend/src/components/SnsPage/PeriodTrendChart.tsx
+++ b/packages/frontend/src/components/SnsPage/PeriodTrendChart.tsx
@@ -1,0 +1,123 @@
+import { useRef } from 'react';
+import { Box, Typography } from '@mui/material';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ResponsiveContainer,
+} from 'recharts';
+import { NormalizedRecord } from '../../types';
+import { CardTheme, CardSize, CARD_THEMES } from '../../constants';
+import { recordHealthScore } from '../../utils/metrics';
+import ChartExportButton from '../shared/ChartExportButton';
+import EmptyStateBox from '../shared/EmptyStateBox';
+
+interface PeriodTrendChartProps {
+  records: NormalizedRecord[];   // 期間フィルタ済みレコード
+  period: 'weekly' | 'monthly';
+  theme: CardTheme;
+  size: CardSize;
+}
+
+export default function PeriodTrendChart({ records, period, theme, size: _size }: PeriodTrendChartProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const t = CARD_THEMES[theme];
+  const primaryColor = t.primaryColor;
+
+  // 日付ごとにグループ化してスコアを平均
+  const byDate = new Map<string, number[]>();
+  for (const r of records) {
+    const d = r.timestamp.slice(5, 10).replace('-', '/'); // "MM/DD"
+    const s = recordHealthScore(r);
+    if (!byDate.has(d)) byDate.set(d, []);
+    byDate.get(d)!.push(s);
+  }
+  const data = Array.from(byDate.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, scores]) => ({
+      date,
+      score: Math.round(scores.reduce((s, v) => s + v, 0) / scores.length),
+    }));
+  const avgScore =
+    data.length > 0 ? Math.round(data.reduce((s, d) => s + d.score, 0) / data.length) : 0;
+
+  if (data.length === 0) {
+    return <EmptyStateBox />;
+  }
+
+  const isWeekly = period === 'weekly';
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+        <Typography sx={{ fontSize: 12, color: t.subTextColor, fontWeight: 600 }}>
+          スコア推移
+        </Typography>
+        <ChartExportButton targetRef={cardRef} filename="period-trend" />
+      </Box>
+      <Box
+        ref={cardRef}
+        sx={{
+          background: t.background,
+          borderRadius: 3,
+          p: 2,
+          border: `1px solid ${t.borderColor}`,
+        }}
+      >
+        <ResponsiveContainer width="100%" height={240}>
+          <AreaChart data={data} margin={{ top: 10, right: 16, left: 0, bottom: isWeekly ? 30 : 10 }}>
+            <defs>
+              <linearGradient id="scoreGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={primaryColor} stopOpacity={0.4} />
+                <stop offset="95%" stopColor={primaryColor} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(0,0,0,0.08)" />
+            {isWeekly ? (
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 12, angle: -30 }}
+                textAnchor="end"
+                interval={0}
+                height={50}
+              />
+            ) : (
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 11 }}
+                interval={4}
+                height={30}
+              />
+            )}
+            <YAxis domain={[0, 100]} ticks={[0, 25, 50, 75, 100]} tick={{ fontSize: 11 }} />
+            <Tooltip
+              contentStyle={{ fontSize: 12 }}
+              formatter={(value: number) => [`${value}点`, 'スコア']}
+            />
+            {!isWeekly && (
+              <ReferenceLine
+                y={avgScore}
+                stroke="#bdbdbd"
+                strokeDasharray="4 4"
+                label={{ value: `平均 ${avgScore}`, position: 'insideTopRight', fontSize: 10 }}
+              />
+            )}
+            <Area
+              type="monotone"
+              dataKey="score"
+              stroke={primaryColor}
+              strokeWidth={isWeekly ? 3 : 2}
+              fill="url(#scoreGrad)"
+              dot={isWeekly ? { r: 6, fill: primaryColor } : false}
+              activeDot={{ r: 9 }}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/frontend/src/components/SnsPage/index.tsx
+++ b/packages/frontend/src/components/SnsPage/index.tsx
@@ -1,10 +1,8 @@
 // ============================================================
-// [Add] PBI-37: SNS出力用画面（Twitter 最適化レイアウト）
-// [Add] PBI-38: 生成AI向けプロンプト生成
-// [Add] PBI-54: テーマ・サイズプリセット統合
+// [Add] #57 #60: SnsPage 週次/月次モード・分析タブ追加
 // ============================================================
 
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import {
   Alert,
   Box,
@@ -13,706 +11,268 @@ import {
   CardContent,
   Chip,
   Grid,
-  IconButton,
-  InputAdornment,
-  OutlinedInput,
+  Tab,
+  Tabs,
   ToggleButton,
   ToggleButtonGroup,
-  Tooltip,
   Typography,
-  useMediaQuery,
-  useTheme,
 } from '@mui/material';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
-import SpaIcon from '@mui/icons-material/Spa';
-import NotificationsIcon from '@mui/icons-material/Notifications';
-import SkinRadarChart from '../Dashboard/SkinRadarChart';
-import TrendChart from '../Dashboard/TrendChart';
-import CalendarHeatmap from '../Dashboard/CalendarHeatmap';
+import NotificationsNoneIcon from '@mui/icons-material/NotificationsNone';
+// 既存コンポーネント
 import LoadingBox from '../shared/LoadingBox';
 import PageHeader from '../shared/PageHeader';
-import ChartExportButton from '../shared/ChartExportButton';
-import { useSkinData, useCosmeticsMaster } from '../../hooks/useSkinData';
-import { useNotifications } from '../../hooks/useNotifications';
-import { NormalizedRecord, SkinMetrics } from '../../types';
-import { formatFullDate } from '../../utils/format';
-import { recordHealthScore } from '../../utils/metrics';
-import { METRIC_COLORS, METRIC_LABELS, SCALE_MAX, CARD_THEMES, CARD_SIZES, CardTheme, CardSize } from '../../constants';
-import WeeklySummaryCard from './WeeklySummaryCard';
-import WeeklyScoreCard from './WeeklyScoreCard';
-import BeforeAfterCard from './BeforeAfterCard';
-import CompactCalendarHeatmap from './CompactCalendarHeatmap';
+import EmptyStateBox from '../shared/EmptyStateBox';
+// 分析タブ用（Dashboard からimport）
+import CosmeticsRadarChart from '../Dashboard/CosmeticsRadarChart';
+import FactorsRadarChart from '../Dashboard/FactorsRadarChart';
+// SnsPage カード
+import PeriodSummaryCard from './PeriodSummaryCard';
+import PeriodTrendChart from './PeriodTrendChart';
+import CombinedBeforeAfterCard from './CombinedBeforeAfterCard';
 import CosmeticsRankingCard from './CosmeticsRankingCard';
 import FactorsInsightCard from './FactorsInsightCard';
+import CompactCalendarHeatmap from './CompactCalendarHeatmap';
+// フック・ユーティリティ
+import { useSkinData, useCosmeticsMaster } from '../../hooks/useSkinData';
+import { useNotifications } from '../../hooks/useNotifications';
+import { CardTheme, CardSize, CARD_THEMES, CARD_SIZES } from '../../constants';
+import { getPrevWeekRange, getPrevMonthRange, filterByDateRange } from '../../utils/dateRange';
 
-// ============================================================
-// スコアに応じた色・ラベルを返すユーティリティ（0-100 正規化スコアを想定）
-// ============================================================
-function scoreColor(v: number): string {
-  if (v >= 70) return '#388e3c';
-  if (v >= 45) return '#e65100';
-  return '#c62828';
-}
-function scoreBgColor(v: number): string {
-  if (v >= 70) return '#e8f5e9';
-  if (v >= 45) return '#fff3e0';
-  return '#fce4ec';
-}
-function scoreLabel(avg: number): string {
-  if (avg >= 75) return '絶好調 ✨';
-  if (avg >= 60) return '良好 💪';
-  if (avg >= 45) return 'まずまず 🌿';
-  return 'ケア強化 🌙';
-}
-
-// ============================================================
-// [Add] PBI-38: 生成AI向けプロンプト生成
-// ============================================================
-function generateAiPrompt(record: NormalizedRecord): string {
-  const date = formatFullDate(record.timestamp);
-  const avg = Math.round(recordHealthScore(record));
-
-  const cosmeticSection = [
-    record.cosmetics.toner   && `　化粧水: ${record.cosmetics.toner}`,
-    record.cosmetics.essence && `　美容液: ${record.cosmetics.essence}`,
-    record.cosmetics.lotion  && `　乳液: ${record.cosmetics.lotion}`,
-    record.cosmetics.primer  && `　下地: ${record.cosmetics.primer}`,
-  ].filter(Boolean);
-
-  // [Fix] sleepHours === 0 は falsy のため !== undefined で判定する
-  const lifelogSection = [
-    record.factors.sleepHours !== undefined && record.factors.sleepHours > 0 && `　睡眠: ${record.factors.sleepHours}時間`,
-    record.factors.businessTrip && '　出張あり',
-    record.factors.alcohol && '　飲酒あり',
-  ].filter(Boolean) as string[];
-
-  return [
-    'あなたはSNS投稿の文章作成アシスタントです。',
-    '以下の肌ケア記録データをもとに、Twitter（X）への投稿文を作成してください。',
-    '',
-    '【要件】',
-    '・前向きで共感を呼ぶトーン',
-    '・絵文字を適度に使用',
-    '・140文字以内（日本語）',
-    '・関連ハッシュタグを末尾に3〜5個追加',
-    '・数値をそのまま羅列せず、感想・体験として語りかける文章にする',
-    '・「SkinJournal」アプリで記録していることを自然に盛り込んでもOK',
-    '',
-    '【肌データ】',
-    `記録日: ${date}`,
-    `総合スコア: ${avg} / ${SCALE_MAX}（${scoreLabel(avg)}）`,
-    '',
-    'おでこ',
-    `　肌色: ${record.forehead.tone}　水分量: ${record.forehead.moisture}　油分量: ${record.forehead.oil}　弾性力: ${record.forehead.elasticity}`,
-    '',
-    'ほお',
-    `　肌色: ${record.cheek.tone}　水分量: ${record.cheek.moisture}　油分量: ${record.cheek.oil}　弾性力: ${record.cheek.elasticity}`,
-    ...(cosmeticSection.length > 0 ? ['', '使用コスメ', ...cosmeticSection] : []),
-    ...(lifelogSection.length > 0 ? ['', 'ライフログ', ...lifelogSection] : []),
-  ].join('\n');
-}
-
-function generateWeeklyAiPrompt(records: NormalizedRecord[]): string {
-  if (records.length === 0) return '';
-  const now = new Date();
-  const weekAgo = new Date(now);
-  weekAgo.setDate(now.getDate() - 7);
-  const weekRecords = records.filter((r) => new Date(r.timestamp) >= weekAgo);
-  if (weekRecords.length === 0) return '';
-
-  const avgScore = Math.round(
-    weekRecords.reduce((s, r) => s + recordHealthScore(r), 0) / weekRecords.length
-  );
-
-  return [
-    'あなたはSNS投稿の文章作成アシスタントです。',
-    '以下の週間肌ケアデータをもとに、Twitter（X）への週次投稿文を作成してください。',
-    '',
-    '【要件】',
-    '・前向きで振り返りを促すトーン',
-    '・絵文字を適度に使用',
-    '・140文字以内（日本語）',
-    '・関連ハッシュタグを末尾に3〜5個追加',
-    '',
-    '【週間データ】',
-    `記録件数: ${weekRecords.length}件`,
-    `週間平均スコア: ${avgScore} / ${SCALE_MAX}（${scoreLabel(avgScore)}）`,
-  ].join('\n');
-}
-
-// ============================================================
-// スコアサマリーカード（正方形出力用・一目で状態がわかるデザイン）
-// ============================================================
-interface SummaryCardProps {
-  record: NormalizedRecord;
-}
-
-const METRIC_ORDER: (keyof SkinMetrics)[] = ['tone', 'moisture', 'oil', 'elasticity'];
-
-// 指標バブル: conic-gradient リングで % を表現し、内側に数値を表示
-function MetricBubble({ label, value, color }: { label: string; value: number; color: string }) {
-  const pct = Math.round(Math.min(100, Math.max(0, (value - 20) / 50 * 100)));
-  return (
-    <Box display="flex" flexDirection="column" alignItems="center" gap={0.75}>
-      <Box
-        sx={{
-          width: { xs: 60, sm: 68 },
-          height: { xs: 60, sm: 68 },
-          borderRadius: '50%',
-          background: `conic-gradient(${color} ${pct}%, ${color}22 0%)`,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Box
-          sx={{
-            width: { xs: 46, sm: 52 },
-            height: { xs: 46, sm: 52 },
-            borderRadius: '50%',
-            bgcolor: 'white',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <Typography sx={{ fontSize: { xs: 15, sm: 17 }, fontWeight: 800, color, lineHeight: 1 }}>
-            {value}
-          </Typography>
-        </Box>
-      </Box>
-      <Typography sx={{ fontSize: { xs: 10, sm: 11 }, color: '#757575', lineHeight: 1, textAlign: 'center' }}>
-        {label}
-      </Typography>
-    </Box>
-  );
-}
-
-function ScoreSummaryCard({ record }: SummaryCardProps) {
-  const avg = Math.round(recordHealthScore(record));
-  const color   = scoreColor(avg);
-  const bgColor = scoreBgColor(avg);
-  const progressPct = avg; // 既に 0-100
-
-  return (
-    <Box
-      sx={{
-        background: 'linear-gradient(150deg, #fff8f9 0%, #fce4ec 55%, #ede7f6 100%)',
-        borderRadius: 3,
-        p: { xs: 2, sm: 3 },
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 2,
-      }}
-    >
-      {/* ── ヘッダー ── */}
-      <Box display="flex" justifyContent="space-between" alignItems="center">
-        <Box display="flex" alignItems="center" gap={0.5}>
-          <SpaIcon sx={{ color: '#e91e63', fontSize: 16 }} />
-          <Typography sx={{ fontSize: 13, fontWeight: 700, color: '#c2185b', letterSpacing: 0.5 }}>
-            SkinJournal
-          </Typography>
-        </Box>
-        <Typography sx={{ fontSize: 11, color: '#9e9e9e' }}>
-          {formatFullDate(record.timestamp)}
-        </Typography>
-      </Box>
-
-      {/* ── 総合スコア（conic-gradient リング） ── */}
-      <Box
-        sx={{
-          bgcolor: 'white',
-          borderRadius: 2,
-          p: { xs: 1.5, sm: 2 },
-          display: 'flex',
-          alignItems: 'center',
-          gap: 2,
-          boxShadow: '0 1px 6px rgba(0,0,0,0.07)',
-        }}
-      >
-        <Box
-          sx={{
-            width: { xs: 64, sm: 72 },
-            height: { xs: 64, sm: 72 },
-            borderRadius: '50%',
-            background: `conic-gradient(${color} ${progressPct}%, ${color}22 0%)`,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            flexShrink: 0,
-          }}
-        >
-          <Box
-            sx={{
-              width: { xs: 50, sm: 56 },
-              height: { xs: 50, sm: 56 },
-              borderRadius: '50%',
-              bgcolor: bgColor,
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <Typography sx={{ fontSize: { xs: 20, sm: 22 }, fontWeight: 900, lineHeight: 1, color }}>
-              {avg}
-            </Typography>
-            <Typography sx={{ fontSize: 8, color: '#bdbdbd', lineHeight: 1.2 }}>
-              /{SCALE_MAX}
-            </Typography>
-          </Box>
-        </Box>
-
-        <Box flex={1} minWidth={0}>
-          <Typography sx={{ fontSize: 10, color: '#9e9e9e', mb: 0.3 }}>総合スコア</Typography>
-          <Typography sx={{ fontSize: { xs: 16, sm: 18 }, fontWeight: 800, color: '#212121', lineHeight: 1.2 }}>
-            {scoreLabel(avg)}
-          </Typography>
-          {/* 各指標平均（肌色除外） */}
-          <Box display="flex" gap={1} mt={0.5} flexWrap="wrap">
-            {[
-              { label: '水分', key: 'moisture' as const },
-              { label: '油分', key: 'oil' as const },
-              { label: '弾性', key: 'elasticity' as const },
-            ].map(({ label, key }) => (
-              <Typography key={key} sx={{ fontSize: 9, color: '#757575', lineHeight: 1 }}>
-                {label} {Math.round((record.forehead[key] + record.cheek[key]) / 2)}
-              </Typography>
-            ))}
-          </Box>
-        </Box>
-      </Box>
-
-      {/* ── おでこ / ほお 指標（2×2 バブルグリッド） ── */}
-      <Grid container spacing={1.5}>
-        {(['forehead', 'cheek'] as const).map((area) => (
-          <Grid item xs={6} key={area}>
-            <Box
-              sx={{
-                bgcolor: 'white',
-                borderRadius: 2,
-                p: { xs: 1.5, sm: 2 },
-                boxShadow: '0 1px 4px rgba(0,0,0,0.06)',
-                borderTop: `3px solid ${area === 'forehead' ? '#e91e63' : '#7986cb'}`,
-              }}
-            >
-              <Typography
-                sx={{
-                  fontSize: 12,
-                  fontWeight: 700,
-                  color: area === 'forehead' ? '#e91e63' : '#7986cb',
-                  mb: 1.5,
-                }}
-              >
-                {area === 'forehead' ? 'おでこ' : 'ほお'}
-              </Typography>
-              <Box
-                sx={{
-                  display: 'grid',
-                  gridTemplateColumns: '1fr 1fr',
-                  gap: { xs: 1.5, sm: 2 },
-                  justifyItems: 'center',
-                }}
-              >
-                {METRIC_ORDER.map((key) => (
-                  <MetricBubble
-                    key={key}
-                    label={METRIC_LABELS[key]}
-                    value={record[area][key]}
-                    color={METRIC_COLORS[key]}
-                  />
-                ))}
-              </Box>
-            </Box>
-          </Grid>
-        ))}
-      </Grid>
-
-      {/* ── 使用コスメタグ ── */}
-      {(record.cosmetics.toner || record.cosmetics.essence || record.cosmetics.lotion || record.cosmetics.primer) && (
-        <Box display="flex" flexWrap="wrap" gap={0.75}>
-          {[
-            { label: '化粧水', value: record.cosmetics.toner },
-            { label: '美容液', value: record.cosmetics.essence },
-            { label: '乳液',   value: record.cosmetics.lotion },
-            { label: '下地',   value: record.cosmetics.primer },
-          ].filter((c) => c.value).map((c) => (
-            <Box key={c.label} sx={{ bgcolor: '#fce4ec', borderRadius: 1.5, px: 1.2, py: 0.4 }}>
-              <Typography sx={{ fontSize: 10, color: '#c2185b' }}>
-                {c.label}: {c.value}
-              </Typography>
-            </Box>
-          ))}
-        </Box>
-      )}
-    </Box>
-  );
-}
-
-// ============================================================
-// SNSページ本体
-// ============================================================
 export default function SnsPage() {
-  const { records, loading, error } = useSkinData('all');
-  const { master } = useCosmeticsMaster();
-  const latestRecord = records.length > 0 ? records[records.length - 1] : null;
-  const muiTheme = useTheme();
-  const isMobile = useMediaQuery(muiTheme.breakpoints.down('sm'));
-
-  // [Add] PBI-37: 日次/週次切り替え
-  const [mode, setMode] = useState<'daily' | 'weekly'>('daily');
-  // [Add] PBI-54: テーマ・サイズプリセット
+  const [mainTab, setMainTab] = useState<number>(0);
+  const [mode, setMode] = useState<'weekly' | 'monthly'>('weekly');
   const [theme, setTheme] = useState<CardTheme>('pastel');
   const [size, setSize] = useState<CardSize>('square');
 
-  const [prompt, setPrompt] = useState<string>('');
-  const [copied, setCopied] = useState(false);
+  const { records: allRecords, loading, error } = useSkinData('all');
+  const { master } = useCosmeticsMaster();
+  const { requestPermission, permission } = useNotifications(allRecords);
 
-  const summaryRef  = useRef<HTMLDivElement>(null);
-  const radarRef    = useRef<HTMLDivElement>(null);
-  const trendRef    = useRef<HTMLDivElement>(null);
-  const calendarRef = useRef<HTMLDivElement>(null);
+  const range = mode === 'weekly' ? getPrevWeekRange() : getPrevMonthRange();
+  const filteredRecords = filterByDateRange(allRecords, range.start, range.end);
 
-  // [Add] PBI-53: ブラウザ通知
-  const { requestPermission, permission } = useNotifications(records);
-
-  const handleGeneratePrompt = () => {
-    if (mode === 'daily') {
-      if (!latestRecord) return;
-      setPrompt(generateAiPrompt(latestRecord));
-    } else {
-      setPrompt(generateWeeklyAiPrompt(records));
-    }
-  };
-
-  const handleCopyPrompt = async () => {
-    if (!prompt) return;
-    try {
-      await navigator.clipboard.writeText(prompt);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // ignore
-    }
-  };
+  // 前期間のレコード（比較用）
+  const prevRange =
+    mode === 'weekly'
+      ? {
+          start: new Date(range.start.getTime() - 7 * 86400000),
+          end: new Date(range.end.getTime() - 7 * 86400000),
+        }
+      : {
+          start: new Date(range.start.getFullYear(), range.start.getMonth() - 1, 1),
+          end: new Date(range.start.getTime() - 1),
+        };
+  const prevRecords = filterByDateRange(allRecords, prevRange.start, prevRange.end);
 
   return (
     <Box>
-      <PageHeader
-        title="SNS出力"
-        subtitle="グラフをダウンロード・コピーしてTwitter（X）に投稿しましょう"
-      />
-
+      <PageHeader title="SNS出力" subtitle="肌ケアの記録をSNSでシェアしましょう" />
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
-      {/* ── [Add] PBI-37 / PBI-54: コントロールバー ── */}
-      <Card elevation={0} sx={{ mb: 3 }}>
-        <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
-          <Box display="flex" flexWrap="wrap" gap={2} alignItems="flex-start">
-            <Box>
-              <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>モード</Typography>
-              <ToggleButtonGroup
-                size="small"
-                value={mode}
-                exclusive
-                onChange={(_, v) => v && setMode(v as 'daily' | 'weekly')}
-              >
-                <ToggleButton value="daily" sx={{ fontSize: 12, px: 2 }}>日次</ToggleButton>
-                <ToggleButton value="weekly" sx={{ fontSize: 12, px: 2 }}>週次</ToggleButton>
-              </ToggleButtonGroup>
-            </Box>
-
-            <Box>
-              <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>テーマ</Typography>
-              <Box display="flex" flexWrap="wrap" gap={0.75}>
-                {(Object.keys(CARD_THEMES) as CardTheme[]).map((t) => (
-                  <Chip
-                    key={t}
-                    label={CARD_THEMES[t].label}
-                    size="small"
-                    onClick={() => setTheme(t)}
-                    sx={{
-                      bgcolor: theme === t ? CARD_THEMES[t].chipColor : undefined,
-                      fontWeight: theme === t ? 700 : 400,
-                      border: theme === t ? '2px solid #9c27b0' : '1px solid #e0e0e0',
-                      cursor: 'pointer',
-                    }}
-                  />
-                ))}
-              </Box>
-            </Box>
-
-            <Box>
-              <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>サイズ</Typography>
-              <ToggleButtonGroup
-                size="small"
-                value={size}
-                exclusive
-                onChange={(_, v) => v && setSize(v as CardSize)}
-              >
-                {(Object.keys(CARD_SIZES) as CardSize[]).map((s) => (
-                  <ToggleButton key={s} value={s} sx={{ fontSize: 11, px: 1.5 }}>
-                    {CARD_SIZES[s].icon} {CARD_SIZES[s].label}
-                  </ToggleButton>
-                ))}
-              </ToggleButtonGroup>
-            </Box>
-
-            {permission === 'default' && (
-              <Box>
-                <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>通知</Typography>
-                <Button
-                  size="small"
-                  variant="outlined"
-                  startIcon={<NotificationsIcon />}
-                  onClick={requestPermission}
-                >
-                  通知を許可
-                </Button>
-              </Box>
-            )}
-          </Box>
-        </CardContent>
-      </Card>
+      {/* メインタブ */}
+      <Tabs
+        value={mainTab}
+        onChange={(_: unknown, v: number) => setMainTab(v)}
+        sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
+      >
+        <Tab label="SNS出力" />
+        <Tab label="分析ツール" />
+      </Tabs>
 
       {loading ? (
         <LoadingBox />
       ) : (
-        <Grid container spacing={{ xs: 2, sm: 3 }}>
-
-          {mode === 'daily' ? (
-            <>
-              {/* ── 日次: スコアサマリー ── */}
-              {latestRecord && (
-                <Grid item xs={12} md={6}>
-                  <Card elevation={0}>
-                    <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                      <Box display="flex" justifyContent="space-between" alignItems="center" mb={1.5}>
-                        <Box>
-                          <Typography variant="subtitle1" fontWeight={600}>スコアサマリー</Typography>
-                          <Typography variant="caption" color="text.secondary">1:1 正方形（Twitter推奨）</Typography>
-                        </Box>
-                        <ChartExportButton targetRef={summaryRef} filename="sns-skin-summary" />
-                      </Box>
-                      <Box ref={summaryRef}>
-                        <ScoreSummaryCard record={latestRecord} />
-                      </Box>
-                    </CardContent>
-                  </Card>
-                </Grid>
-              )}
-
-              {/* ── 日次: レーダーチャート ── */}
-              <Grid item xs={12} md={6}>
-                <Card elevation={0}>
-                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                    <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
-                      <Box>
-                        <Typography variant="subtitle1" fontWeight={600}>最新肌状態</Typography>
-                        <Typography variant="caption" color="text.secondary">1:1 正方形</Typography>
-                      </Box>
-                      <ChartExportButton targetRef={radarRef} filename="sns-skin-radar" />
-                    </Box>
-                    {/* [Add] PBI-37: 正方形コンテナ */}
-                    <Box
-                      ref={radarRef}
-                      sx={{
-                        aspectRatio: '1 / 1',
-                        bgcolor: '#fafafa',
-                        borderRadius: 2,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        justifyContent: 'center',
-                        p: { xs: 1, sm: 2 },
-                        overflow: 'hidden',
-                      }}
-                    >
-                      <SkinRadarChart record={latestRecord} />
-                    </Box>
-                  </CardContent>
-                </Card>
-              </Grid>
-
-              {/* ── 日次: 推移グラフ ── */}
-              <Grid item xs={12}>
-                <Card elevation={0}>
-                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                    <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
-                      <Box>
-                        <Typography variant="subtitle1" fontWeight={600}>推移グラフ</Typography>
-                        <Typography variant="caption" color="text.secondary">横長（16:9 相当）</Typography>
-                      </Box>
-                      <ChartExportButton targetRef={trendRef} filename="sns-skin-trend" />
-                    </Box>
-                    <Box ref={trendRef} sx={{ bgcolor: 'background.paper', borderRadius: 2 }}>
-                      <TrendChart records={records} />
-                    </Box>
-                  </CardContent>
-                </Card>
-              </Grid>
-
-              {/* ── 日次: 365日カレンダー ── */}
-              <Grid item xs={12}>
-                <Card elevation={0}>
-                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                    <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
-                      <Box>
-                        <Typography variant="subtitle1" fontWeight={600}>365日カレンダー</Typography>
-                        <Typography variant="caption" color="text.secondary">横長</Typography>
-                      </Box>
-                      <ChartExportButton targetRef={calendarRef} filename="sns-skin-calendar" />
-                    </Box>
-                    <Box ref={calendarRef} sx={{ bgcolor: 'background.paper', borderRadius: 2 }}>
-                      <CalendarHeatmap records={records} />
-                    </Box>
-                  </CardContent>
-                </Card>
-              </Grid>
-
-              {/* ── 日次: BeforeAfterCard ── */}
-              <Grid item xs={12} md={6}>
-                <Card elevation={0}>
-                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                    <Typography variant="subtitle1" fontWeight={600} mb={1.5}>Before / After 比較</Typography>
-                    <BeforeAfterCard records={records} theme={theme} size={size} />
-                  </CardContent>
-                </Card>
-              </Grid>
-            </>
-          ) : (
-            <>
-              {/* ── 週次: WeeklySummaryCard ── */}
-              <Grid item xs={12} md={6}>
-                <Card elevation={0}>
-                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                    <Typography variant="subtitle1" fontWeight={600} mb={1.5}>週間サマリー</Typography>
-                    <WeeklySummaryCard records={records} theme={theme} size={size} />
-                  </CardContent>
-                </Card>
-              </Grid>
-
-              {/* ── 週次: TrendChart ── */}
-              <Grid item xs={12}>
-                <Card elevation={0}>
-                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                    <Typography variant="subtitle1" fontWeight={600} mb={1}>推移グラフ（週次）</Typography>
-                    <TrendChart records={records} />
-                  </CardContent>
-                </Card>
-              </Grid>
-
-              {/* ── 週次: WeeklyScoreCard ── */}
-              <Grid item xs={12} md={6}>
-                <Card elevation={0}>
-                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                    <Typography variant="subtitle1" fontWeight={600} mb={1.5}>週間スコアカード</Typography>
-                    <WeeklyScoreCard records={records} theme={theme} size={size} />
-                  </CardContent>
-                </Card>
-              </Grid>
-
-              {/* ── 週次: BeforeAfterCard ── */}
-              <Grid item xs={12} md={6}>
-                <Card elevation={0}>
-                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                    <Typography variant="subtitle1" fontWeight={600} mb={1.5}>Before / After 比較</Typography>
-                    <BeforeAfterCard records={records} theme={theme} size={size} />
-                  </CardContent>
-                </Card>
-              </Grid>
-            </>
-          )}
-
-          {/* ── 両モード共通: CompactCalendarHeatmap ── */}
-          <Grid item xs={12} md={6}>
-            <Card elevation={0}>
-              <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                <Typography variant="subtitle1" fontWeight={600} mb={1.5}>直近3ヶ月カレンダー</Typography>
-                <CompactCalendarHeatmap records={records} theme={theme} size={size} />
-              </CardContent>
-            </Card>
-          </Grid>
-
-          {/* ── 両モード共通: CosmeticsRankingCard ── */}
-          <Grid item xs={12} md={6}>
-            <Card elevation={0}>
-              <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                <Typography variant="subtitle1" fontWeight={600} mb={1.5}>コスメランキング</Typography>
-                <CosmeticsRankingCard records={records} master={master} theme={theme} size={size} />
-              </CardContent>
-            </Card>
-          </Grid>
-
-          {/* ── 両モード共通: FactorsInsightCard ── */}
-          <Grid item xs={12} md={6}>
-            <Card elevation={0}>
-              <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                <Typography variant="subtitle1" fontWeight={600} mb={1.5}>生活習慣インサイト</Typography>
-                <FactorsInsightCard records={records} theme={theme} size={size} />
-              </CardContent>
-            </Card>
-          </Grid>
-
-          {/* ── 生成AIプロンプト ── */}
-          <Grid item xs={12}>
-            <Card elevation={0}>
-              <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                <Box
-                  display="flex"
-                  justifyContent="space-between"
-                  alignItems={{ sm: 'center' }}
-                  flexDirection={{ xs: 'column', sm: 'row' }}
-                  gap={1}
-                  mb={1.5}
+        <>
+          {/* ── SNS出力タブ ── */}
+          {mainTab === 0 && (
+            <Box>
+              {/* コントロールバー */}
+              <Box display="flex" gap={2} flexWrap="wrap" alignItems="center" mb={2}>
+                <ToggleButtonGroup
+                  size="small"
+                  exclusive
+                  value={mode}
+                  onChange={(_: unknown, v: 'weekly' | 'monthly' | null) => {
+                    if (v) setMode(v);
+                  }}
                 >
-                  <Box>
-                    <Typography variant="subtitle1" fontWeight={600}>生成AIプロンプト</Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      ChatGPT / Claude 等に貼り付けてSNS投稿文を作成できます
-                    </Typography>
-                  </Box>
+                  <ToggleButton value="weekly">週次</ToggleButton>
+                  <ToggleButton value="monthly">月次</ToggleButton>
+                </ToggleButtonGroup>
+
+                {/* テーマ選択 */}
+                <Box display="flex" gap={0.5}>
+                  {(Object.entries(CARD_THEMES) as [CardTheme, typeof CARD_THEMES[CardTheme]][]).map(
+                    ([key, t]) => (
+                      <Chip
+                        key={key}
+                        label={t.label}
+                        size="small"
+                        onClick={() => setTheme(key)}
+                        variant={theme === key ? 'filled' : 'outlined'}
+                        sx={{ bgcolor: theme === key ? t.chipColor : undefined, fontSize: 11 }}
+                      />
+                    )
+                  )}
+                </Box>
+
+                {/* サイズ選択 */}
+                <ToggleButtonGroup
+                  size="small"
+                  exclusive
+                  value={size}
+                  onChange={(_: unknown, v: CardSize | null) => {
+                    if (v) setSize(v);
+                  }}
+                >
+                  {(Object.entries(CARD_SIZES) as [CardSize, typeof CARD_SIZES[CardSize]][]).map(
+                    ([key, s]) => (
+                      <ToggleButton key={key} value={key} sx={{ fontSize: 11 }}>
+                        {s.icon} {s.label}
+                      </ToggleButton>
+                    )
+                  )}
+                </ToggleButtonGroup>
+
+                {/* 通知許可ボタン */}
+                {permission === 'default' && (
                   <Button
                     size="small"
-                    startIcon={<AutoAwesomeIcon />}
-                    onClick={handleGeneratePrompt}
-                    disabled={mode === 'daily' ? !latestRecord : records.length === 0}
+                    startIcon={<NotificationsNoneIcon />}
+                    onClick={requestPermission}
                     variant="outlined"
-                    fullWidth={isMobile}
                   >
-                    プロンプトを生成
+                    通知を許可
                   </Button>
-                </Box>
-                <OutlinedInput
-                  multiline
-                  rows={isMobile ? 8 : 12}
-                  fullWidth
-                  value={prompt}
-                  onChange={(e) => setPrompt(e.target.value)}
-                  placeholder="「プロンプトを生成」ボタンで最新の肌データからAIプロンプトを作成します。そのままChatGPT・Claude等に貼り付けてください。"
-                  endAdornment={
-                    prompt ? (
-                      <InputAdornment position="end" sx={{ alignSelf: 'flex-start', mt: 1 }}>
-                        <Tooltip title={copied ? 'コピーしました！' : 'クリップボードにコピー'}>
-                          <IconButton size="small" onClick={handleCopyPrompt}>
-                            <ContentCopyIcon fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
-                      </InputAdornment>
-                    ) : null
-                  }
-                  sx={{ fontSize: 13 }}
-                />
-                {mode === 'daily' && !latestRecord && (
-                  <Typography variant="caption" color="text.secondary" mt={0.5} display="block">
-                    ※ 肌データを記録するとプロンプトを生成できます
-                  </Typography>
                 )}
-              </CardContent>
-            </Card>
-          </Grid>
+              </Box>
 
-        </Grid>
+              {/* 期間ラベル */}
+              <Typography variant="body2" color="text.secondary" mb={2}>
+                {mode === 'weekly' ? '前週' : '前月'}: {range.label}
+              </Typography>
+
+              {filteredRecords.length === 0 ? (
+                <EmptyStateBox message={`${range.label} の期間にデータがありません`} />
+              ) : (
+                <Grid container spacing={{ xs: 2, sm: 3 }}>
+                  {/* サマリーカード */}
+                  <Grid item xs={12} md={6}>
+                    <Card elevation={0}>
+                      <CardContent>
+                        <Typography variant="subtitle1" fontWeight={600} mb={1}>
+                          サマリー
+                        </Typography>
+                        <PeriodSummaryCard
+                          records={filteredRecords}
+                          prevRecords={prevRecords}
+                          label={range.label}
+                          mode={mode}
+                          theme={theme}
+                          size={size}
+                        />
+                      </CardContent>
+                    </Card>
+                  </Grid>
+
+                  {/* 推移グラフ */}
+                  <Grid item xs={12} md={6}>
+                    <Card elevation={0}>
+                      <CardContent>
+                        <Typography variant="subtitle1" fontWeight={600} mb={1}>
+                          推移グラフ
+                        </Typography>
+                        <PeriodTrendChart
+                          records={filteredRecords}
+                          period={mode}
+                          theme={theme}
+                          size={size}
+                        />
+                      </CardContent>
+                    </Card>
+                  </Grid>
+
+                  {/* 複合BeforeAfter */}
+                  <Grid item xs={12}>
+                    <Card elevation={0}>
+                      <CardContent>
+                        <Typography variant="subtitle1" fontWeight={600} mb={1}>
+                          肌変化レポート（週・月・3ヶ月）
+                        </Typography>
+                        <CombinedBeforeAfterCard records={allRecords} theme={theme} size={size} />
+                      </CardContent>
+                    </Card>
+                  </Grid>
+                </Grid>
+              )}
+            </Box>
+          )}
+
+          {/* ── 分析ツールタブ ── */}
+          {mainTab === 1 && (
+            <Grid container spacing={{ xs: 2, sm: 3 }}>
+              <Grid item xs={12} md={6}>
+                <Card elevation={0}>
+                  <CardContent>
+                    <Typography variant="subtitle1" fontWeight={600} mb={1}>
+                      コスメランキング
+                    </Typography>
+                    <CosmeticsRankingCard
+                      records={allRecords}
+                      master={master}
+                      theme="minimal"
+                      size="square"
+                    />
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              <Grid item xs={12} md={6}>
+                <Card elevation={0}>
+                  <CardContent>
+                    <Typography variant="subtitle1" fontWeight={600} mb={1}>
+                      生活習慣インサイト
+                    </Typography>
+                    <FactorsInsightCard records={allRecords} theme="minimal" size="square" />
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              <Grid item xs={12} md={6}>
+                <Card elevation={0}>
+                  <CardContent>
+                    <Typography variant="subtitle1" fontWeight={600} mb={1}>
+                      コスメ比較レーダー
+                    </Typography>
+                    <CosmeticsRadarChart records={allRecords} />
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              <Grid item xs={12} md={6}>
+                <Card elevation={0}>
+                  <CardContent>
+                    <Typography variant="subtitle1" fontWeight={600} mb={1}>
+                      生活習慣比較レーダー
+                    </Typography>
+                    <FactorsRadarChart records={allRecords} />
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              <Grid item xs={12}>
+                <Card elevation={0}>
+                  <CardContent>
+                    <Typography variant="subtitle1" fontWeight={600} mb={1}>
+                      90日カレンダー
+                    </Typography>
+                    <CompactCalendarHeatmap records={allRecords} theme="minimal" size="square" />
+                  </CardContent>
+                </Card>
+              </Grid>
+            </Grid>
+          )}
+        </>
       )}
     </Box>
   );

--- a/packages/frontend/src/utils/dateRange.ts
+++ b/packages/frontend/src/utils/dateRange.ts
@@ -1,0 +1,63 @@
+import { NormalizedRecord } from '../types';
+
+export interface DateRange {
+  start: Date;
+  end: Date;
+  label: string;
+}
+
+/** 前週の月曜日 00:00:00 〜 日曜日 23:59:59 */
+export function getPrevWeekRange(): DateRange {
+  const now = new Date();
+  const day = now.getDay(); // 0=日, 1=月, ..., 6=土
+  const daysToThisMonday = day === 0 ? 6 : day - 1;
+  const thisMonday = new Date(now);
+  thisMonday.setDate(now.getDate() - daysToThisMonday);
+  thisMonday.setHours(0, 0, 0, 0);
+
+  const lastMonday = new Date(thisMonday);
+  lastMonday.setDate(thisMonday.getDate() - 7);
+
+  const lastSunday = new Date(lastMonday);
+  lastSunday.setDate(lastMonday.getDate() + 6);
+  lastSunday.setHours(23, 59, 59, 999);
+
+  const fmt = (d: Date) => `${d.getMonth() + 1}/${d.getDate()}`;
+  const DOW = ['日','月','火','水','木','金','土'];
+  const label = `${fmt(lastMonday)}(${DOW[lastMonday.getDay()]}) 〜 ${fmt(lastSunday)}(${DOW[lastSunday.getDay()]})`;
+
+  return { start: lastMonday, end: lastSunday, label };
+}
+
+/** 前月の1日 00:00:00 〜 末日 23:59:59 */
+export function getPrevMonthRange(): DateRange {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth() - 1, 1, 0, 0, 0, 0);
+  const end = new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999);
+  const label = `${start.getFullYear()}年${start.getMonth() + 1}月`;
+  return { start, end, label };
+}
+
+/** 過去 N 日間（今日から N 日前の 00:00:00 〜 今日 23:59:59） */
+export function getPastDaysRange(days: number): DateRange {
+  const end = new Date();
+  end.setHours(23, 59, 59, 999);
+  const start = new Date();
+  start.setDate(start.getDate() - days + 1);
+  start.setHours(0, 0, 0, 0);
+  return { start, end, label: `過去${days}日間` };
+}
+
+/** records を start〜end でフィルタして timestamp 昇順に返す */
+export function filterByDateRange(
+  records: NormalizedRecord[],
+  start: Date,
+  end: Date
+): NormalizedRecord[] {
+  return records
+    .filter(r => {
+      const t = new Date(r.timestamp);
+      return t >= start && t <= end;
+    })
+    .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+}


### PR DESCRIPTION
## Why

SNS出力を実用的な週次・月次レポートに特化させ、分析機能を別タブへ分離することで、SNS投稿フローを明確化する。

resolves #57
resolves #58
resolves #59
resolves #60

## What

- **#57** SNS出力モードを「週次（前週月〜日）/月次（前月1日〜末日）」に変更、日次を廃止
- **#58** 期間専用の推移グラフ（PeriodTrendChart）— 週次はドット強調・月次は点線平均ライン
- **#59** 複合BeforeAfterCard — 週/月/3ヶ月を縦1枚に統合してエクスポート
- **#60** SnsPage を「SNS出力」「分析ツール」2タブ構成に変更、コスメランキング・インサイト・レーダーチャートを分析タブへ移設

## How

**新規ファイル:**
- `utils/dateRange.ts` — `getPrevWeekRange()` / `getPrevMonthRange()` / `getPastDaysRange()` / `filterByDateRange()`
- `SnsPage/PeriodSummaryCard.tsx` — 期間平均スコア・ランク・指標別平均・前期比を表示するサマリーカード
- `SnsPage/PeriodTrendChart.tsx` — 期間モード対応の AreaChart（週次: dot大・全ラベル / 月次: dot無し・5日おきラベル + 平均 ReferenceLine）
- `SnsPage/CombinedBeforeAfterCard.tsx` — 前週・前月・過去90日の3期間 BeforeAfter を縦1枚に集約

**SnsPage/index.tsx 全面改訂:**
- Tab 0「SNS出力」: コントロールバー（週次/月次 + テーマ + サイズ）+ 期間ラベル + PeriodSummaryCard + PeriodTrendChart + CombinedBeforeAfterCard
- Tab 1「分析ツール」: CosmeticsRankingCard + FactorsInsightCard + CosmeticsRadarChart + FactorsRadarChart + CompactCalendarHeatmap
- `filteredRecords` = 選択期間でフィルタ済み（SNS出力タブ用）
- `allRecords` = 全期間（分析タブ用）

**依存関係:** PR #56（feature/milestone6-sns-integration）のマージ後にマージ可能

## Test

- [ ] 週次モード選択時: 前週月〜日のデータのみ各カードに反映される（期間ラベル確認）
- [ ] 月次モード選択時: 前月1日〜末日のデータのみ各カードに反映される
- [ ] 対象期間にデータがない場合: EmptyStateBox が表示される
- [ ] PeriodTrendChart — 週次で7プロット点が大きく表示、月次で点線平均ラインが出る
- [ ] CombinedBeforeAfterCard — 3期間を縦1枚で PNG エクスポートできる
- [ ] 「分析ツール」タブにコスメランキング・インサイト・レーダーチャートが表示される
- [ ] テーマ変更（pastel/minimal/pop/luxury）が SNS出力カードに反映される


---
_Generated by [Claude Code](https://claude.ai/code/session_01MDw6ttZniXXg5wJdqfUvtD)_